### PR TITLE
Changed wildcard syntax for 'nuget' CLI push command

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
     - main
-    paths:
-    - '**.cs'
-    - '**.csproj'
 
 jobs:
   build:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,6 +28,6 @@ jobs:
         nuget pack .\BassClefStudio.AppModel.Uwp\BassClefStudio.AppModel.Uwp.csproj
     - name: Nuget Push
       run: |
-        nuget push ".*.nupkg" -Source "GPR" -SkipDuplicate -NoSymbols
+        nuget push "*.nupkg" -Source "GPR" -SkipDuplicate -NoSymbols
         dotnet nuget push ".\BassClefStudio.AppModel\bin\Debug\*.nupkg" --source "GPR" --skip-duplicate --no-symbols true
         dotnet nuget push ".\BassClefStudio.AppModel.Console\bin\Debug\*.nupkg" --source "GPR" --skip-duplicate --no-symbols true


### PR DESCRIPTION
Hopefully the `.UWP` package pushes now...