### PR TITLE
API Keys added to Nuget

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,7 +18,8 @@ jobs:
       uses: microsoft/setup-msbuild@v1.0.2
     - name: Add GitHub Packages for Nuget
       run: |
-        nuget sources add -Source https://nuget.pkg.github.com/bassclefstudio/index.json -Name "GPR" -Username bassclefstudio -Password ${{ secrets.GITHUB_TOKEN }} -StorePasswordInClearText
+        nuget sources add -Source https://nuget.pkg.github.com/bassclefstudio/index.json -Name "GPR" -Username bassclefstudio
+        nuget setapikey ${{ secrets.GITHUB_TOKEN }} -Source https://nuget.pkg.github.com/bassclefstudio/index.json
     - name: MSBuild
       run: msbuild BassClefStudio.AppModel.sln -t:build -p:Configuration=Debug -p:Platform="Any CPU" -m -restore
     - name: Nuget Pack


### PR DESCRIPTION
Nuget packages built with CI now use the `--api-key` flag (or equivalent, set in initialization) to connect to GitHub Packages service.