### PR TITLE
v1.0.4 - Revealed the reflection-based navigation methods on the App class.

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,10 +24,10 @@ jobs:
     - name: Nuget Pack
       run: |
         dotnet pack .\BassClefStudio.AppModel\BassClefStudio.AppModel.csproj --no-build
-        dotnet pack .\BassClefStudio.AppModel.Console\BassClefStudio.AppModel.Console.csproj --no-build
+        dotnet pack .\BassClefStudio.AppModel.Base\BassClefStudio.AppModel.Base.csproj --no-build
         nuget pack .\BassClefStudio.AppModel.Uwp\BassClefStudio.AppModel.Uwp.csproj
     - name: Nuget Push
       run: |
         nuget push "*.nupkg" -Source "GPR" -SkipDuplicate -NoSymbols
         dotnet nuget push ".\BassClefStudio.AppModel\bin\Debug\*.nupkg" --source "GPR" --skip-duplicate --no-symbols true
-        dotnet nuget push ".\BassClefStudio.AppModel.Console\bin\Debug\*.nupkg" --source "GPR" --skip-duplicate --no-symbols true
+        dotnet nuget push ".\BassClefStudio.AppModel.Base\bin\Debug\*.nupkg" --source "GPR" --skip-duplicate --no-symbols true

--- a/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
+++ b/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
@@ -7,7 +7,7 @@
     <Description>A .NET Standard, platform-agnostic library for creating cross-platform view-models and applications for various .NET platforms.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
-    <Version>1.0.3-beta</Version>
+    <Version>1.0.4-beta</Version>
     <AssemblyName>BassClefStudio.AppModel</AssemblyName>
   </PropertyGroup>
 

--- a/BassClefStudio.AppModel/Lifecycle/App.cs
+++ b/BassClefStudio.AppModel/Lifecycle/App.cs
@@ -117,8 +117,23 @@ namespace BassClefStudio.AppModel.Lifecycle
         /// <summary>
         /// Resolves the given <see cref="IViewModel"/>'s view dependencies for the platform and navigates to a new view. Uses reflection to find the <see cref="IView"/> and <see cref="IViewModel"/> types.
         /// </summary>
+        /// <param name="viewModelType">The type of the <see cref="IViewModel"/> to set as the <see cref="IView"/>'s context.</param>
+        public void NavigateReflection(Type viewModelType)
+        {
+            var viewType = typeof(IView<>).MakeGenericType(viewModelType);
+            var viewModel = (IViewModel)Services.Resolve(viewModelType);
+            var view = (IView)Services.Resolve(viewType);
+            var navService = Services.Resolve<INavigationService>();
+            navService.Navigate(view);
+            viewType.GetProperty("ViewModel").SetValue(view, viewModel);
+            NavigatedInitialize(viewModel, view);
+        }
+
+        /// <summary>
+        /// Resolves the given <see cref="IViewModel"/>'s view dependencies for the platform and navigates to a new view. Uses reflection to find the <see cref="IView"/> and <see cref="IViewModel"/> types.
+        /// </summary>
         /// <param name="viewModel">An instance of the <see cref="IViewModel"/> to set as the <see cref="IView"/>'s context.</param>
-        internal void NavigateReflection(IViewModel viewModel)
+        public void NavigateReflection(IViewModel viewModel)
         {
             var viewType = typeof(IView<>).MakeGenericType(viewModel.GetType());
             var view = (IView)Services.Resolve(viewType);


### PR DESCRIPTION
The `NavigateReflection(Type viewModelType)` and `NavigateReflection(IViewModel viewModel)` now work, using reflection instead of generic `T` typing. This patch also adds the `.Base` library to the Nuget package, which should close #7 on successful push.