### PR TITLE
v1.0.5 for UWP - UWP navigation supports ContentControl source, dialogs, etc.

### DIFF
--- a/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
+++ b/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>BassClefStudio.AppModel.Uwp</id>
-    <version>1.0.3-beta</version>
+    <version>1.0.5-beta</version>
     <title>BassClefStudio.AppModel.Uwp</title>
     <authors>BassClefStudio</authors>
     <owners>BassClefStudio</owners>
@@ -12,7 +12,7 @@
     <dependencies>
       <group targetFramework="uap10.0.17763">
         <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.2.10"/>
-        <dependency id="BassClefStudio.AppModel" version="1.0.3-beta"/>
+        <dependency id="BassClefStudio.AppModel" version="1.0.5-beta"/>
       </group>
     </dependencies>
   </metadata>

--- a/BassClefStudio.AppModel.Uwp/Navigation/UwpNavigationService.cs
+++ b/BassClefStudio.AppModel.Uwp/Navigation/UwpNavigationService.cs
@@ -1,4 +1,5 @@
 ﻿using BassClefStudio.AppModel.Navigation;
+using BassClefStudio.NET.Core;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -12,7 +13,7 @@ namespace BassClefStudio.AppModel.Navigation
 {
     public class UwpNavigationService : INavigationService
     {
-        public Frame CurrentFrame { get; set; }
+        public ContentControl CurrentFrame { get; set; }
         
         /// <inheritdoc/>
         public void InitializeNavigation()
@@ -42,7 +43,20 @@ namespace BassClefStudio.AppModel.Navigation
                 Debug.Write($"UWP Navigation usually expects that the resolved IViews be UIElements. View type: {view?.GetType().Name}");
             }
 
-            CurrentFrame.Content = view;
+            if (view is ContentDialog dialog)
+            {
+                SynchronousTask showTask = new SynchronousTask(() => ShowDialogTask(dialog));
+                showTask.RunTask();
+            }
+            else
+            {
+                CurrentFrame.Content = view;
+            }
+        }
+
+        private async Task<ContentDialogResult> ShowDialogTask(ContentDialog dialog)
+        {
+            return await dialog.ShowAsync();
         }
     }
 }


### PR DESCRIPTION
`UwpNavigationService` allows `CurrentFrame` to be set to any `ContentControl`, and will navigate correctly and asynchronously to `ContentDialog` views.