### PR TITLE
v1.1.0 - Background Tasks Support

### DIFF
--- a/BassClefStudio.AppModel.Uwp/Background/UwpBackgroundService.cs
+++ b/BassClefStudio.AppModel.Uwp/Background/UwpBackgroundService.cs
@@ -1,0 +1,89 @@
+﻿using BassClefStudio.AppModel.Lifecycle;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.ApplicationModel.Background;
+
+namespace BassClefStudio.AppModel.Background
+{
+    /// <summary>
+    /// The UWP implementation of <see cref="IBackgroundService"/>, which manages background tasks in UWP using the system broker.
+    /// </summary>
+    public class UwpBackgroundService : IBackgroundService, IInitializationHandler
+    {
+        /// <summary>
+        /// The collection of UWP <see cref="IBackgroundTaskRegistration"/>s that define the currently registered background tasks.
+        /// </summary>
+        internal List<IBackgroundTaskRegistration> Registrations { get; private set; }
+
+        /// <inheritdoc/>
+        public IEnumerable<string> CurrentlyRegistered => Registrations.Select(r => r.Name);
+
+        /// <inheritdoc/>
+        public bool Enabled { get; } = true;
+
+        /// <summary>
+        /// Creates a new <see cref="UwpBackgroundService"/>.
+        /// </summary>
+        public UwpBackgroundService()
+        { }
+
+        /// <inheritdoc/>
+        public bool Initialize(App app)
+        {
+            Registrations = new List<IBackgroundTaskRegistration>(BackgroundTaskRegistration.AllTasks.Values);
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public async Task<bool> RegisterAsync(IBackgroundTask task)
+        {
+            var backgroundStatus = await BackgroundExecutionManager.RequestAccessAsync();
+            if (backgroundStatus == BackgroundAccessStatus.AllowedSubjectToSystemPolicy
+               || backgroundStatus == BackgroundAccessStatus.AlwaysAllowed)
+            {
+                var builder = new BackgroundTaskBuilder();
+                builder.IsNetworkRequested = task.Capabilities.HasFlag(BackgroundTaskCapability.Internet);
+                builder.Name = task.Id;
+                builder.SetTrigger(task.Trigger.GetTrigger());
+                Registrations.Add(builder.Register());
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <inheritdoc/>
+        public void UnRegister(string taskName)
+        {
+            var task = Registrations.FirstOrDefault(r => r.Name == taskName);
+            if(task != null)
+            {
+                task.Unregister(false);
+                Registrations.Remove(task);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Provides UWP platform extensions for <see cref="IBackgroundTask"/> and related types.
+    /// </summary>
+    internal static class BackgroundTaskExtensions
+    {
+        public static IBackgroundTrigger GetTrigger(this BackgroundTaskTrigger trigger)
+        {
+            if(trigger is TimeBackgroundTaskTrigger timeTrigger)
+            {
+                return new TimeTrigger((uint)timeTrigger.Time.TotalMinutes, !timeTrigger.Continuous);
+            }
+            else
+            {
+                throw new ArgumentException($"BackgroundTaskTrigger of unknown type {trigger.GetType().Name}");
+            }
+        }
+    }
+}

--- a/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.csproj
+++ b/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.csproj
@@ -121,6 +121,7 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Background\UwpBackgroundService.cs" />
     <Compile Include="Lifecycle\UwpApplication.cs" />
     <Compile Include="Navigation\UwpNavigationService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
+++ b/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>BassClefStudio.AppModel.Uwp</id>
-    <version>1.0.7-beta</version>
+    <version>1.1.0-beta</version>
     <title>BassClefStudio.AppModel.Uwp</title>
     <authors>BassClefStudio</authors>
     <owners>BassClefStudio</owners>
@@ -12,7 +12,7 @@
     <dependencies>
       <group targetFramework="uap10.0.17763">
         <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.2.10"/>
-        <dependency id="BassClefStudio.AppModel" version="1.0.6-beta"/>
+        <dependency id="BassClefStudio.AppModel" version="1.1.0-beta"/>
       </group>
     </dependencies>
   </metadata>

--- a/BassClefStudio.AppModel.Uwp/Lifecycle/UwpAppPlatform.cs
+++ b/BassClefStudio.AppModel.Uwp/Lifecycle/UwpAppPlatform.cs
@@ -1,4 +1,5 @@
 ﻿using Autofac;
+using BassClefStudio.AppModel.Background;
 using BassClefStudio.AppModel.Navigation;
 using BassClefStudio.AppModel.Settings;
 using BassClefStudio.AppModel.Storage;
@@ -15,6 +16,9 @@ namespace BassClefStudio.AppModel.Lifecycle
         public void ConfigureServices(ContainerBuilder builder)
         {
             builder.RegisterType<UwpNavigationService>()
+                .SingleInstance()
+                .AsImplementedInterfaces();
+            builder.RegisterType<UwpBackgroundService>()
                 .SingleInstance()
                 .AsImplementedInterfaces();
             builder.RegisterType<UwpFileSystemService>()

--- a/BassClefStudio.AppModel/Background/BackgroundTaskTrigger.cs
+++ b/BassClefStudio.AppModel/Background/BackgroundTaskTrigger.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BassClefStudio.AppModel.Background
+{
+    /// <summary>
+    /// Represents a trigger for an <see cref="IBackgroundTask"/>.
+    /// </summary>
+    public abstract class BackgroundTaskTrigger
+    {
+    }
+
+    /// <summary>
+    /// A <see cref="BackgroundTaskTrigger"/> that triggers after a certain length of time.
+    /// </summary>
+    public class TimeBackgroundTaskTrigger : BackgroundTaskTrigger
+    {
+        /// <summary>
+        /// A <see cref="TimeSpan"/> indicating the desired amount of time before the <see cref="IBackgroundTask"/> is triggered.
+        /// </summary>
+        public TimeSpan Time { get; }
+
+        /// <summary>
+        /// A <see cref="bool"/> indicating whether the <see cref="IBackgroundTask"/> should continue to be fired after every <see cref="Time"/> has elapsed.
+        /// </summary>
+        public bool Continuous { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="TimeBackgroundTaskTrigger"/>.
+        /// </summary>
+        /// <param name="timeSpan">A <see cref="TimeSpan"/> indicating the desired amount of time before the <see cref="IBackgroundTask"/> is triggered.</param>
+        /// <param name="continuous">A <see cref="bool"/> indicating whether the <see cref="IBackgroundTask"/> should continue to be fired after every <see cref="Time"/> has elapsed.</param>
+        public TimeBackgroundTaskTrigger(TimeSpan timeSpan, bool continuous)
+        {
+            Time = timeSpan;
+            Continuous = continuous;
+        }
+    }
+}

--- a/BassClefStudio.AppModel/Background/IBackgroundService.cs
+++ b/BassClefStudio.AppModel/Background/IBackgroundService.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BassClefStudio.AppModel.Background
+{
+    /// <summary>
+    /// Represents a platform-provided service for registering and unregistering <see cref="IBackgroundTask"/>s.
+    /// </summary>
+    public interface IBackgroundService
+    {
+        /// <summary>
+        /// A collection of <see cref="string"/> IDs for all of the registered background tasks in the system.
+        /// </summary>
+        IEnumerable<string> CurrentlyRegistered { get; }
+
+        /// <summary>
+        /// Registers an <see cref="IBackgroundTask"/> to the <see cref="IBackgroundService"/>, allowing it to be triggered in the background by the system at a later time.
+        /// </summary>
+        /// <param name="task">The task to register.</param>
+        /// <returns>A <see cref="bool"/> indicating whether the operation succeeded.</returns>
+        Task<bool> RegisterAsync(IBackgroundTask task);
+
+        /// <summary>
+        /// Removes the registration of the <see cref="IBackgroundTask"/> with the given name from this <see cref="IBackgroundService"/>.
+        /// </summary>
+        /// <param name="taskName">The <see cref="IBackgroundTask"/>'s <see cref="string"/> ID, as found in the <see cref="CurrentlyRegistered"/> collection.</param>
+        void UnRegister(string taskName);
+    }
+
+    /// <summary>
+    /// Contains extension methods for the <see cref="IBackgroundService"/> interface.
+    /// </summary>
+    public static class BackgroundServiceExtensions
+    {
+        /// <summary>
+        /// Syncs the currently registered <see cref="IBackgroundTask"/>s on the given <see cref="IBackgroundService"/> to match a collection of <see cref="IBackgroundTask"/>s.
+        /// </summary>
+        /// <param name="service">The <see cref="IBackgroundService"/> used for registering/unregistering background tasks.</param>
+        /// <param name="tasks">The desired collection of <see cref="IBackgroundTask"/>s to register.</param>
+        public static async Task RegisterCollectionAsync(this IBackgroundService service, IEnumerable<IBackgroundTask> tasks)
+        {
+            var toRemove = service.CurrentlyRegistered.Where(r => !tasks.Any(t => t.Id == r)).ToArray();
+            var toAdd = tasks.Where(t => !service.CurrentlyRegistered.Any(r => r == t.Id)).ToArray();
+            foreach (var name in toRemove)
+            {
+                service.UnRegister(name);
+            }
+
+            foreach (var task in toAdd)
+            {
+                await service.RegisterAsync(task);
+            }
+        }
+    }
+}

--- a/BassClefStudio.AppModel/Background/IBackgroundTask.cs
+++ b/BassClefStudio.AppModel/Background/IBackgroundTask.cs
@@ -1,0 +1,20 @@
+﻿using BassClefStudio.AppModel.Lifecycle;
+using BassClefStudio.NET.Core;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BassClefStudio.AppModel.Background
+{
+    /// <summary>
+    /// Represents a service that can provide a task that this <see cref="App"/> can run in the background.
+    /// </summary>
+    public interface IBackgroundTask : IIdentifiable<string>
+    {
+        /// <summary>
+        /// Asynchronously executes this <see cref="IBackgroundTask"/>'s action.
+        /// </summary>
+        Task RunAsync();
+    }
+}

--- a/BassClefStudio.AppModel/Background/IBackgroundTask.cs
+++ b/BassClefStudio.AppModel/Background/IBackgroundTask.cs
@@ -8,13 +8,35 @@ using System.Threading.Tasks;
 namespace BassClefStudio.AppModel.Background
 {
     /// <summary>
-    /// Represents a service that can provide a task that this <see cref="App"/> can run in the background.
+    /// Represents an <see cref="ILifecycleHandler"/> that can provide a task that this <see cref="App"/> can run in the background.
     /// </summary>
-    public interface IBackgroundTask : IIdentifiable<string>
+    public interface IBackgroundTask : ILifecycleHandler, IIdentifiable<string>
     {
+        /// <summary>
+        /// The <see cref="BackgroundTaskCapability"/> flags that indicate any capabilities this <see cref="IBackgroundTask"/> will require when running.
+        /// </summary>
+        BackgroundTaskCapability Capabilities { get; }
+
+        /// <summary>
+        /// The <see cref="BackgroundTaskTrigger"/> trigger for executing this <see cref="IBackgroundTask"/>.
+        /// </summary>
+        BackgroundTaskTrigger Trigger { get; }
+
         /// <summary>
         /// Asynchronously executes this <see cref="IBackgroundTask"/>'s action.
         /// </summary>
         Task RunAsync();
+    }
+
+    /// <summary>
+    /// An enum containing the possible capabilities that an <see cref="IBackgroundTask"/> could request while running.
+    /// </summary>
+    [Flags]
+    public enum BackgroundTaskCapability
+    {
+        /// <summary>
+        /// The <see cref="IBackgroundTask"/> will require the internet connectivity stack to remain running (e.g. to use <see cref="System.Net.Http.HttpClient"/>).
+        /// </summary>
+        Internet = 1
     }
 }

--- a/BassClefStudio.AppModel/Background/IDeferral.cs
+++ b/BassClefStudio.AppModel/Background/IDeferral.cs
@@ -1,0 +1,18 @@
+﻿using BassClefStudio.AppModel.Lifecycle;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BassClefStudio.AppModel.Background
+{
+    /// <summary>
+    /// Represents the deferral of an action such as background launch or suspension in an <see cref="App"/> to allow for the completion of asynchronous tasks in those situations.
+    /// </summary>
+    public interface IDeferral
+    {
+        /// <summary>
+        /// Stops the <see cref="IDeferral"/>, continuing the system code.
+        /// </summary>
+        void EndDeferral();
+    }
+}

--- a/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
+++ b/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
@@ -7,7 +7,7 @@
     <Description>A .NET Standard, platform-agnostic library for creating cross-platform view-models and applications for various .NET platforms.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
-    <Version>1.0.6-beta</Version>
+    <Version>1.1.0-beta</Version>
     <AssemblyName>BassClefStudio.AppModel</AssemblyName>
   </PropertyGroup>
 

--- a/BassClefStudio.AppModel/Lifecycle/App.cs
+++ b/BassClefStudio.AppModel/Lifecycle/App.cs
@@ -81,6 +81,8 @@ namespace BassClefStudio.AppModel.Lifecycle
             }
             else
             {
+                SynchronousTask registerTask = new SynchronousTask(RegisterBackgroundTasks);
+                registerTask.RunTask();
                 ActivateForeground(args);
             }
         }
@@ -96,6 +98,7 @@ namespace BassClefStudio.AppModel.Lifecycle
                 IBackgroundTask myTask = tasks.FirstOrDefault(t => t.Id == args.TaskName);
                 if (myTask != null)
                 {
+                    //// Intentionally started without SynchronousTask, in order for the try/catch/finally block can be used to ensure the deferral is executed.
                     RunBackgroundTask(myTask, deferral);
                 }
                 else
@@ -122,6 +125,21 @@ namespace BassClefStudio.AppModel.Lifecycle
             finally
             {
                 deferral.EndDeferral();
+            }
+        }
+
+        private async Task RegisterBackgroundTasks()
+        {
+            var service = Services.ResolveOptional<IBackgroundService>();
+            if (service != null)
+            {
+                IEnumerable<IBackgroundTask> tasks = Services.Resolve<IEnumerable<IBackgroundTask>>();
+                await service.RegisterCollectionAsync(tasks);
+                Debug.WriteLine($"Background tasks registered: {string.Join(",", service.CurrentlyRegistered)}.");
+            }
+            else
+            {
+                Debug.WriteLine("Background activation has not been set up for the given platform.");
             }
         }
 

--- a/BassClefStudio.AppModel/Lifecycle/IActivatedEventArgs.cs
+++ b/BassClefStudio.AppModel/Lifecycle/IActivatedEventArgs.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using BassClefStudio.AppModel.Background;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -11,7 +12,6 @@ namespace BassClefStudio.AppModel.Lifecycle
     {
     }
 
-    //// C# 9 record?
     /// <summary>
     /// The default <see cref="IActivatedEventArgs"/>, provided when the user normally started an <see cref="App"/>.
     /// </summary>
@@ -29,6 +29,31 @@ namespace BassClefStudio.AppModel.Lifecycle
         public LaunchActivatedEventArgs(params string[] args)
         {
             Args = args;
+        }
+    }
+
+    /// <summary>
+    /// The base <see cref="IActivatedEventArgs"/> for <see cref="App"/> activation that occurs in the background and does not trigger UI.
+    /// </summary>
+    public abstract class BackgroundActivatedEventArgs : IActivatedEventArgs
+    {
+        /// <summary>
+        /// The identifiable name of the background task that should be executed.
+        /// </summary>
+        public string TaskName { get; }
+
+        /// <summary>
+        /// Creates or retreieves the <see cref="IDeferral"/> that can be used for managing this background task.
+        /// </summary>
+        public abstract IDeferral GetDeferral();
+
+        /// <summary>
+        /// Creates a new <see cref="BackgroundActivatedEventArgs"/>.
+        /// </summary>
+        /// <param name="taskName">The identifiable name of the background task that should be executed.</param>
+        public BackgroundActivatedEventArgs(string taskName)
+        {
+            TaskName = taskName;
         }
     }
 }


### PR DESCRIPTION
The `IBackgroundTask` and `IBackgroundService` interfaces provide an easy way to create background tasks in the .NET Standard model/view-model project, as well as the platform implementation of `IBackgroundService` which allows platforms to register and unregister background tasks to the system broker/another process/another thread (as the platform allows).