### PR TITLE
v1.2.2 - BaseSettingsService bugfixes

### DIFF
--- a/BassClefStudio.AppModel.Base/BassClefStudio.AppModel.Base.csproj
+++ b/BassClefStudio.AppModel.Base/BassClefStudio.AppModel.Base.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>BassClefStudio</Authors>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
     <Description>Services and classes for the BassClefStudio.AppModel library that provide basic features for cross-platform MVVM applications running on .NET Standard.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>

--- a/BassClefStudio.AppModel.Base/Settings/BaseSettingsService.cs
+++ b/BassClefStudio.AppModel.Base/Settings/BaseSettingsService.cs
@@ -12,7 +12,7 @@ namespace BassClefStudio.AppModel.Settings
     public class BaseSettingsService : ISettingsService
     {
         private IStorageService StorageService { get; }
-        private List<BaseSetting> Settings { get; set; }
+        private List<BaseSetting> Settings { get; }
 
         /// <summary>
         /// Creates a <see cref="BaseSettingsService"/> for managing settings.

--- a/BassClefStudio.AppModel.Base/Settings/BaseSettingsService.cs
+++ b/BassClefStudio.AppModel.Base/Settings/BaseSettingsService.cs
@@ -21,6 +21,7 @@ namespace BassClefStudio.AppModel.Settings
         public BaseSettingsService(IStorageService storageService)
         {
             StorageService = storageService;
+            Settings = new List<BaseSetting>();
         }
 
         private async Task ReadSettings(bool refresh = false)
@@ -28,7 +29,12 @@ namespace BassClefStudio.AppModel.Settings
             if(Settings == null || refresh)
             {
                 var file = await StorageService.AppDataFolder.CreateFileAsync("Settings.json", CollisionOptions.OpenExisting);
-                Settings = JsonConvert.DeserializeObject<BaseSetting[]>(await file.ReadTextAsync()).ToList();
+                var json = JsonConvert.DeserializeObject<BaseSetting[]>(await file.ReadTextAsync());
+                if(json != null)
+                {
+                    Settings.Clear();
+                    Settings.AddRange(json);
+                }
             }
         }
 


### PR DESCRIPTION
This closes #25, and initializes the `Settings` list in the constructor of the `BaseSettingsService` to avoid list errors.