### PR TITLE
v1.2.4 - WPF Startup Issue

### DIFF
--- a/BassClefStudio.AppModel.Wpf/BassClefStudio.AppModel.Wpf.csproj
+++ b/BassClefStudio.AppModel.Wpf/BassClefStudio.AppModel.Wpf.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Authors>BassClefStudio</Authors>
-    <Version>1.2.3</Version>
+    <Version>1.2.4</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications on .NET 5 with WPF.</Description>

--- a/BassClefStudio.AppModel.Wpf/Lifecycle/WpfApplication.cs
+++ b/BassClefStudio.AppModel.Wpf/Lifecycle/WpfApplication.cs
@@ -28,10 +28,10 @@ namespace BassClefStudio.AppModel.Wpf
             CurrentApp.Initialize(new WpfAppPlatform(), viewAssemblies);
         }
 
-        protected override void OnActivated(EventArgs e)
+        protected override void OnStartup(StartupEventArgs e)
         {
             CurrentApp.Activate(new LaunchActivatedEventArgs());
-            base.OnActivated(e);
+            base.OnStartup(e);
         }
     }
 }


### PR DESCRIPTION
WPF apps should no longer restart when moved between foreground and background with `.Wpf` package version `v1.2.4`.