### PR TITLE
v1.3.1 - fixes UWP background tasks issue

### DIFF
--- a/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
+++ b/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>BassClefStudio.AppModel.Uwp</id>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <title>BassClefStudio.AppModel.Uwp</title>
     <authors>BassClefStudio</authors>
     <owners>BassClefStudio</owners>

--- a/BassClefStudio.AppModel.Uwp/Lifecycle/UwpApplication.cs
+++ b/BassClefStudio.AppModel.Uwp/Lifecycle/UwpApplication.cs
@@ -5,6 +5,9 @@ using System.Linq;
 using System.Reflection;
 using Windows.ApplicationModel.Activation;
 using Windows.UI.Core;
+using BassClefStudio.AppModel.Navigation;
+using Autofac;
+using BassClefStudio.AppModel.Threading;
 
 namespace BassClefStudio.AppModel.Lifecycle
 {
@@ -34,6 +37,8 @@ namespace BassClefStudio.AppModel.Lifecycle
         {
             ////Register system events
             this.Suspending += OnSuspending;
+            this.EnteredBackground += EnterBackground;
+            this.LeavingBackground += LeaveBackground;
 
             CurrentApp = app;
             CurrentApp.Initialize(new UwpAppPlatform(), viewAssemblies);
@@ -54,6 +59,24 @@ namespace BassClefStudio.AppModel.Lifecycle
 
         #endregion
         #region Events
+
+        private void LeaveBackground(object sender, Windows.ApplicationModel.LeavingBackgroundEventArgs e)
+        {
+            var dService = CurrentApp?.Services.Resolve<IDispatcherService>();
+            if (dService is UwpDispatcherService uwpDispatcherService)
+            {
+                uwpDispatcherService.Activated = true;
+            }
+        }
+
+        private void EnterBackground(object sender, Windows.ApplicationModel.EnteredBackgroundEventArgs e)
+        {
+            var dService = CurrentApp?.Services.Resolve<IDispatcherService>();
+            if (dService is UwpDispatcherService uwpDispatcherService)
+            {
+                uwpDispatcherService.Activated = false;
+            }
+        }
 
         private void BackRequested(object sender, BackRequestedEventArgs e)
         {

--- a/BassClefStudio.AppModel.Uwp/Threading/UwpDispatcherService.cs
+++ b/BassClefStudio.AppModel.Uwp/Threading/UwpDispatcherService.cs
@@ -9,34 +9,67 @@ namespace BassClefStudio.AppModel.Threading
     /// </summary>
     public class UwpDispatcherService : IDispatcherService
     {
+        /// <summary>
+        /// A get/set-able <see cref="bool"/> indicating whether UI thread code needs to be sent through this <see cref="IDispatcherService"/>'s <see cref="CoreDispatcher"/> (i.e. if the app has a foreground UI).
+        /// </summary>
+        public bool Activated { get; set; } = false;
+
         /// <inheritdoc/>
         public async Task RunOnUIThreadAsync(Action execute)
         {
-            await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal,
-                () => execute());
+            if (Activated)
+            {
+                await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal,
+                    () => execute());
+            }
+            else
+            {
+                execute();
+            }
         }
 
         /// <inheritdoc/>
         public async Task<T> RunOnUIThreadAsync<T>(Func<T> execute)
         {
-            T output = default(T);
-            await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal,
-                () => output = execute());
-            return output;
+            if (Activated)
+            {
+                T output = default(T);
+                await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal,
+                    () => output = execute());
+                return output;
+            }
+            else
+            {
+                return execute();
+            }
         }
 
         public async Task RunOnUIThreadAsync<T>(Func<Task> execute)
         {
-            await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal,
-                async () => await execute());
+            if (Activated)
+            {
+                await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal,
+                    async () => await execute());
+            }
+            else
+            {
+                await execute();
+            }
         }
 
         public async Task<T> RunOnUIThreadAsync<T>(Func<Task<T>> execute)
         {
-            T output = default(T);
-            await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal,
-                async () => output = await execute());
-            return output;
+            if (Activated)
+            {
+                T output = default(T);
+                await Windows.ApplicationModel.Core.CoreApplication.MainView.CoreWindow.Dispatcher.RunAsync(CoreDispatcherPriority.Normal,
+                    async () => output = await execute());
+                return output;
+            }
+            else
+            {
+                return await execute();
+            }
         }
     }
 }


### PR DESCRIPTION
The `IDispatcherService` implementation for UWP included code that threw an exception while a UI thread was not present (i.e. when some shared code was running in a background task). This bugfix patch fixes the issue by falling back to `BaseDispatcherService`-esque code when in the background, the `UwpApplication` class managing this through the 'EnteredBackground' and 'LeavingBackground' events.