### PR TITLE
AppModel v1.4.0 - .NET Standard Binding Expressions 

### DIFF
--- a/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
+++ b/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
@@ -7,7 +7,7 @@
     <Description>A .NET Standard, platform-agnostic library for creating cross-platform view-models and applications for various .NET platforms.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <AssemblyName>BassClefStudio.AppModel</AssemblyName>
   </PropertyGroup>
 

--- a/BassClefStudio.AppModel/Bindings/BindingBuilder.cs
+++ b/BassClefStudio.AppModel/Bindings/BindingBuilder.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Text;
+
+namespace BassClefStudio.AppModel.Bindings
+{
+    /// <summary>
+    /// Provides extension methods for creating complex <see cref="IBindingExpression{T}"/>s.
+    /// </summary>
+    public static class BindingExtensions
+    {
+        /// <summary>
+        /// Creates an <see cref="IBindingExpression{T}"/> for a property on an existing <see cref="IBindingExpression{T}"/>'s <see cref="IBindingExpression{T}.Value"/> object.
+        /// </summary>
+        /// <typeparam name="T1">The type of the base object.</typeparam>
+        /// <typeparam name="T2">The type of the property to bind.</typeparam>
+        /// <param name="me">The base object's <see cref="IBindingExpression{T}"/>.</param>
+        /// <param name="getProperty">A <see cref="Func{T, TResult}"/> getting the property on <paramref name="me"/>.</param>
+        /// <returns>A new <see cref="IBindingExpression{T}"/> for the property on the base object.</returns>
+        public static IBindingExpression<T2> GetProperty<T1, T2>(this IBindingExpression<T1> me, Func<T1, T2> getProperty) where T1 : INotifyPropertyChanged
+        {
+            return new PropertyBindingExpression<T1, T2>(me, getProperty);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IBindingExpression{T}"/> for an existing <see cref="IBindingExpression{T}"/> that applies a <see cref="Func{T, TResult}"/> to the existing <see cref="IBindingExpression{T}.Value"/>.
+        /// </summary>
+        /// <typeparam name="T1">The type of the base object.</typeparam>
+        /// <typeparam name="T2">The type of the transformed object.</typeparam>
+        /// <param name="me">The base object's <see cref="IBindingExpression{T}"/>.</param>
+        /// <param name="transform">A <see cref="Func{T, TResult}"/> transforming the base object to type <typeparamref name="T2"/>.</param>
+        /// <returns>A new <see cref="IBindingExpression{T}"/> for the transformed value of the base object.</returns>
+        public static IBindingExpression<T2> Transform<T1, T2>(this IBindingExpression<T1> me, Func<T1, T2> transform)
+        {
+            return new TransformBindingExpression<T1, T2>(me, transform);
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IBindingExpression{T}"/> for an existing <see cref="IBindingExpression{T}"/> that applies a <see cref="Func{T, TResult}"/> to an existing <see cref="IBindingExpression{T}.Value"/> collection.
+        /// </summary>
+        /// <typeparam name="T1">The type of the base collection.</typeparam>
+        /// <typeparam name="T2">The type of the transformed collection.</typeparam>
+        /// <param name="me">The base collection's <see cref="IBindingExpression{T}"/>.</param>
+        /// <param name="transform">A <see cref="Func{T, TResult}"/> transforming the base collection to type <typeparamref name="T2"/>.</param>
+        /// <param name="update">An <see cref="Action{T}"/> that updates the transformed <see cref="IBindingExpression{T}.Value"/> based on changes to the base collection.</param>
+        /// <returns>A new <see cref="IBindingExpression{T}"/> for the transformed collection.</returns>
+        public static IBindingExpression<T2> TransformCollection<T1, T2>(this IBindingExpression<T1> me, Func<T1, T2> transform, Action<NotifyCollectionChangedEventArgs> update) where T1 : INotifyCollectionChanged
+        {
+            return new CollectionTransformBindingExpression<T1, T2>(me, transform, update);
+        }
+    }
+}

--- a/BassClefStudio.AppModel/Bindings/BindingExpression.cs
+++ b/BassClefStudio.AppModel/Bindings/BindingExpression.cs
@@ -1,0 +1,207 @@
+﻿using BassClefStudio.NET.Core;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Text;
+
+namespace BassClefStudio.AppModel.Bindings
+{
+    /// <summary>
+    /// Represents an object that manages the binding to a property on another object. Implements <see cref="INotifyPropertyChanged"/> notifications and event notify (via <see cref="ValueChanged"/> event).
+    /// </summary>
+    /// <typeparam name="T">The type of the value this <see cref="IBindingExpression{T}"/> manages.</typeparam>
+    public interface IBindingExpression<T> : INotifyPropertyChanged
+    {
+        /// <summary>
+        /// The current value of the <see cref="IBindingExpression{T}"/>.
+        /// </summary>
+        T Value { get; }
+
+        /// <summary>
+        /// An event fired when the <see cref="Value"/> property is updated.
+        /// </summary>
+        event EventHandler ValueChanged;
+    }
+
+    /// <summary>
+    /// An abstract class providing an <see cref="Observable"/> base implementation of the <see cref="IBindingExpression{T}"/> interface.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public abstract class BaseBindingExpression<T> : Observable, IBindingExpression<T>
+    {
+        private T bindingValue;
+        /// <inheritdoc/>
+        public T Value { get => bindingValue; protected set { Set(ref bindingValue, value); ValueChanged?.Invoke(this, new EventArgs()); } }
+
+        /// <inheritdoc/>
+        public event EventHandler ValueChanged;
+    }
+
+    /// <summary>
+    /// An <see cref="IBindingExpression{T}"/> that references a constant value.
+    /// </summary>
+    /// <typeparam name="T">The type of the </typeparam>
+    public class ConstantBindingExpression<T> : BaseBindingExpression<T>
+    {
+        /// <summary>
+        /// Creates a new <see cref="ConstantBindingExpression{T}"/>.
+        /// </summary>
+        /// <param name="value">The <typeparamref name="T"/> value to store.</param>
+        public ConstantBindingExpression(T value)
+        {
+            Value = value;
+        }
+    }
+
+    /// <summary>
+    /// A <see cref="IBindingExpression{T}"/> that utilizes the <see cref="INotifyPropertyChanged"/> to bind to a property on a root object referenced by another <see cref="IBindingExpression{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the root object.</typeparam>
+    /// <typeparam name="TProp">The type of the property that this <see cref="IBindingExpression{T}"/> binds to.</typeparam>
+    public class PropertyBindingExpression<T, TProp> : BaseBindingExpression<TProp> where T : INotifyPropertyChanged
+    {
+        /// <summary>
+        /// A <see cref="Func{T, TResult}"/> that returns a <typeparamref name="TProp"/> value from a <typeparamref name="T"/> root object.
+        /// </summary>
+        public Func<T, TProp> GetProperty { get; }
+
+        /// <summary>
+        /// An <see cref="IBindingExpression{T}"/> to the root <typeparamref name="T"/> object.
+        /// </summary>
+        public IBindingExpression<T> ObjectBinding { get; }
+
+        private T RootObject;
+
+        /// <summary>
+        /// Creates a new <see cref="PropertyBindingExpression{T, TProp}"/>.
+        /// </summary>
+        /// <param name="rootObject">An <see cref="IBindingExpression{T}"/> to the root <typeparamref name="T"/> object.</param>
+        /// <param name="getPropertyFunc">A <see cref="Func{T, TResult}"/> that returns a <typeparamref name="TProp"/> value from a <typeparamref name="T"/> root object.</param>
+        public PropertyBindingExpression(IBindingExpression<T> rootObject, Func<T, TProp> getPropertyFunc)
+        {
+            ObjectBinding = rootObject;
+            GetProperty = getPropertyFunc;
+
+            ObjectBinding.ValueChanged += RootChanged;
+            RootChanged();
+        }
+
+        private void RootChanged(object sender, EventArgs e) => RootChanged();
+        private void RootChanged()
+        {
+            if (RootObject != null)
+            {
+                RootObject.PropertyChanged -= RootPropertyChanged;
+            }
+            RootObject = ObjectBinding.Value;
+            if (RootObject != null)
+            {
+                RootObject.PropertyChanged += RootPropertyChanged;
+            }
+        }
+
+        private void RootPropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            Value = GetProperty(RootObject);
+        }
+    }
+
+    /// <summary>
+    /// An <see cref="IBindingExpression{T}"/> that applies a transformation function to an object referenced by a toot <see cref="IBindingExpression{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the root object.</typeparam>
+    /// <typeparam name="TOut">The type of output value this <see cref="IBindingExpression{T}"/> provides.</typeparam>
+    public class TransformBindingExpression<T, TOut> : BaseBindingExpression<TOut>
+    {
+        /// <summary>
+        /// An <see cref="IBindingExpression{T}"/> referencing the root object of this <see cref="TransformBindingExpression{T, TOut}"/>.
+        /// </summary>
+        public IBindingExpression<T> ObjectBinding { get; }
+
+        /// <summary>
+        /// A function applied when <see cref="ObjectBinding"/> is updated to convert an object of type <typeparamref name="T"/> to an object of type <typeparamref name="TOut"/>.
+        /// </summary>
+        public Func<T, TOut> TransformFunc { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="TransformBindingExpression{T, TOut}"/>.
+        /// </summary>
+        /// <param name="objectBinding">An <see cref="IBindingExpression{T}"/> referencing the root object of this <see cref="TransformBindingExpression{T, TOut}"/>.</param>
+        /// <param name="transformFunc">A function applied when <see cref="ObjectBinding"/> is updated to convert an object of type <typeparamref name="T"/> to an object of type <typeparamref name="TOut"/>.</param>
+        public TransformBindingExpression(IBindingExpression<T> objectBinding, Func<T, TOut> transformFunc)
+        {
+            ObjectBinding = objectBinding;
+            TransformFunc = transformFunc;
+
+            ObjectBinding.ValueChanged += RootChanged;
+            RootChanged();
+        }
+
+        private void RootChanged(object sender, EventArgs e) => RootChanged();
+        private void RootChanged()
+        {
+            Value = TransformFunc(ObjectBinding.Value);
+        }
+    }
+
+    /// <summary>
+    /// An <see cref="IBindingExpression{T}"/> that applies a transformation function to a collection referenced by a toot <see cref="IBindingExpression{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the root collection, which should post <see cref="INotifyCollectionChanged"/> events.</typeparam>
+    /// <typeparam name="TOut">The type of output value this <see cref="IBindingExpression{T}"/> provides.</typeparam>
+    public class CollectionTransformBindingExpression<T, TOut> : BaseBindingExpression<TOut> where T : INotifyCollectionChanged
+    {
+        /// <summary>
+        /// An <see cref="IBindingExpression{T}"/> referencing the root object of this <see cref="TransformBindingExpression{T, TOut}"/>.
+        /// </summary>
+        public IBindingExpression<T> ObjectBinding { get; }
+
+        /// <summary>
+        /// A function applied when <see cref="ObjectBinding"/> is updated to convert an object of type <typeparamref name="T"/> to an object of type <typeparamref name="TOut"/>.
+        /// </summary>
+        public Func<T, TOut> TransformFunc { get; }
+
+        /// <summary>
+        /// Called whenever the collection <see cref="ObjectBinding"/> refers to is changed or cleared, allowing for the updating of the existing <typeparamref name="TOut"/> <see cref="BaseBindingExpression{T}.Value"/>.
+        /// </summary>
+        public Action<NotifyCollectionChangedEventArgs> UpdateFunc { get; }
+
+        private T RootObject;
+
+        /// <summary>
+        /// Creates a new <see cref="TransformBindingExpression{T, TOut}"/>.
+        /// </summary>
+        /// <param name="objectBinding">An <see cref="IBindingExpression{T}"/> referencing the root object of this <see cref="TransformBindingExpression{T, TOut}"/>.</param>
+        /// <param name="transformFunc">A function applied when <see cref="ObjectBinding"/> is updated to convert an object of type <typeparamref name="T"/> to an object of type <typeparamref name="TOut"/>.</param>
+        public CollectionTransformBindingExpression(IBindingExpression<T> objectBinding, Func<T, TOut> transformFunc, Action<NotifyCollectionChangedEventArgs> updateFunc)
+        {
+            ObjectBinding = objectBinding;
+            TransformFunc = transformFunc;
+            UpdateFunc = updateFunc;
+            ObjectBinding.ValueChanged += RootChanged;
+            RootChanged();
+        }
+
+        private void RootChanged(object sender, EventArgs e) => RootChanged();
+        private void RootChanged()
+        {
+            if (RootObject != null)
+            {
+                RootObject.CollectionChanged -= RootCollectionChanged;
+            }
+            RootObject = ObjectBinding.Value;
+            if (RootObject != null)
+            {
+                RootObject.CollectionChanged += RootCollectionChanged;
+            }
+
+            Value = TransformFunc(RootObject);
+        }
+
+        private void RootCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            UpdateFunc(e);
+        }
+    }
+}

--- a/BassClefStudio.AppModel/Bindings/BindingExtensions.cs
+++ b/BassClefStudio.AppModel/Bindings/BindingExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using BassClefStudio.AppModel.Navigation;
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
@@ -49,6 +50,17 @@ namespace BassClefStudio.AppModel.Bindings
         public static IBindingExpression<T2> TransformCollection<T1, T2>(this IBindingExpression<T1> me, Func<T1, T2> transform, Action<NotifyCollectionChangedEventArgs> update) where T1 : INotifyCollectionChanged
         {
             return new CollectionTransformBindingExpression<T1, T2>(me, transform, update);
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IBindingExpression{T}"/> to this <see cref="IView{T}"/>'s current <see cref="IView{T}.ViewModel"/>. Call this while or after <see cref="IView.Initialize"/> is called.
+        /// </summary>
+        /// <typeparam name="T">The type of the view-model to bind to.</typeparam>
+        /// <param name="view">The <see cref="IView{T}"/> where the view-model could be found.</param>
+        /// <returns>An <see cref="IBindingExpression{T}"/> binding to the constant value of the current view-model.</returns>
+        public static IBindingExpression<T> ViewModelBinding<T>(this IView<T> view) where T : IViewModel
+        {
+            return new ConstantBindingExpression<T>(view.ViewModel);
         }
     }
 }


### PR DESCRIPTION
Added binding classes that handle property, constant, transform, and collection binding, all of which can be stacked on one another to create complex binding expressions. These center around the `IBindingExpression<T>` interface, which represents a binidng to an object of type `T`.