### PR TITLE
v1.4.1 - Binding fixes

### DIFF
--- a/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
+++ b/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
@@ -7,7 +7,7 @@
     <Description>A .NET Standard, platform-agnostic library for creating cross-platform view-models and applications for various .NET platforms.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
-    <Version>1.4.0</Version>
+    <Version>1.4.1</Version>
     <AssemblyName>BassClefStudio.AppModel</AssemblyName>
   </PropertyGroup>
 

--- a/BassClefStudio.AppModel/Bindings/BindingExpression.cs
+++ b/BassClefStudio.AppModel/Bindings/BindingExpression.cs
@@ -98,12 +98,21 @@ namespace BassClefStudio.AppModel.Bindings
             if (RootObject != null)
             {
                 RootObject.PropertyChanged += RootPropertyChanged;
+                RootPropertyChanged();
             }
         }
 
-        private void RootPropertyChanged(object sender, PropertyChangedEventArgs e)
+        private void RootPropertyChanged(object sender, PropertyChangedEventArgs e) => RootPropertyChanged();
+        private void RootPropertyChanged()
         {
-            Value = GetProperty(RootObject);
+            if (RootObject != null)
+            {
+                Value = GetProperty(RootObject);
+            }
+            else
+            {
+                Value = default(TProp);
+            }
         }
     }
 


### PR DESCRIPTION
Binding with `PropertyBindingExpression<T, TProp>` now sets property `Value` when base object's `IBindingExpression<T>` is updated.