### PR TITLE
Updated the Blazor INavigationService to respect BaseUri

### DIFF
--- a/BassClefStudio.AppModel.Blazor/BassClefStudio.AppModel.Blazor.csproj
+++ b/BassClefStudio.AppModel.Blazor/BassClefStudio.AppModel.Blazor.csproj
@@ -5,14 +5,14 @@
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications on .NET 5 with Blazor.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
-    <Version>1.3.0</Version>
+    <Version>1.4.2</Version>
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.1.0" />
     <PackageReference Include="Blazored.LocalStorage" Version="3.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BassClefStudio.AppModel.Base\BassClefStudio.AppModel.Base.csproj" />

--- a/BassClefStudio.AppModel.Blazor/Navigation/BlazorNavigationService.cs
+++ b/BassClefStudio.AppModel.Blazor/Navigation/BlazorNavigationService.cs
@@ -37,7 +37,7 @@ namespace BassClefStudio.AppModel.Navigation
             if(view is BlazorView blazorView)
             {
                 ViewProvider.CurrentView = blazorView;
-                NavigationManager.NavigateTo(blazorView.ViewPath);
+                NavigationManager.NavigateTo($"{NavigationManager.BaseUri}{blazorView.ViewPath}");
             }
             else
             {

--- a/BassClefStudio.AppModel.Tests/BassClefStudio.AppModel.Tests.csproj
+++ b/BassClefStudio.AppModel.Tests/BassClefStudio.AppModel.Tests.csproj
@@ -10,7 +10,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0" />
+    <PackageReference Include="coverlet.collector" Version="3.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.csproj
+++ b/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.csproj
@@ -138,7 +138,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BassClefStudio.NET.Core">
-      <Version>1.4.2</Version>
+      <Version>1.5.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.11</Version>

--- a/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
+++ b/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>BassClefStudio.AppModel.Uwp</id>
-    <version>1.3.2</version>
+    <version>1.4.2</version>
     <title>BassClefStudio.AppModel.Uwp</title>
     <authors>BassClefStudio</authors>
     <owners>BassClefStudio</owners>

--- a/BassClefStudio.AppModel.Wpf/BassClefStudio.AppModel.Wpf.csproj
+++ b/BassClefStudio.AppModel.Wpf/BassClefStudio.AppModel.Wpf.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Authors>BassClefStudio</Authors>
-    <Version>1.3.0</Version>
+    <Version>1.4.2</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications on .NET 5 with WPF.</Description>

--- a/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
+++ b/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.1.0" />
-    <PackageReference Include="BassClefStudio.NET.Core" Version="1.4.2" />
+    <PackageReference Include="BassClefStudio.NET.Core" Version="1.5.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This enables the deployment of a Blazor app to a path in a domain that is not the top-level (see #37).