### PR TITLE
Collection binding, updated version numbers, and better naming

### DIFF
--- a/BassClefStudio.AppModel.Base/BassClefStudio.AppModel.Base.csproj
+++ b/BassClefStudio.AppModel.Base/BassClefStudio.AppModel.Base.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>BassClefStudio</Authors>
-    <Version>1.3.0</Version>
+    <Version>1.5.1</Version>
     <Description>Services and classes for the BassClefStudio.AppModel library that provide basic features for cross-platform MVVM applications running on .NET Standard.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>

--- a/BassClefStudio.AppModel.Blazor/BassClefStudio.AppModel.Blazor.csproj
+++ b/BassClefStudio.AppModel.Blazor/BassClefStudio.AppModel.Blazor.csproj
@@ -5,7 +5,7 @@
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications on .NET 5 with Blazor.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
-    <Version>1.4.2</Version>
+    <Version>1.5.1</Version>
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
+++ b/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>BassClefStudio.AppModel.Uwp</id>
-    <version>1.4.2</version>
+    <version>1.5.1</version>
     <title>BassClefStudio.AppModel.Uwp</title>
     <authors>BassClefStudio</authors>
     <owners>BassClefStudio</owners>
@@ -12,7 +12,7 @@
     <dependencies>
       <group targetFramework="uap10.0.17763">
         <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.2.10"/>
-        <dependency id="BassClefStudio.AppModel" version="1.3.0"/>
+        <dependency id="BassClefStudio.AppModel" version="1.5.1"/>
         <dependency id="Microsoft.Toolkit.Uwp.Notifications" version="6.1.0"/>
       </group>
     </dependencies>

--- a/BassClefStudio.AppModel.Wpf/BassClefStudio.AppModel.Wpf.csproj
+++ b/BassClefStudio.AppModel.Wpf/BassClefStudio.AppModel.Wpf.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Authors>BassClefStudio</Authors>
-    <Version>1.4.2</Version>
+    <Version>1.5.1</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications on .NET 5 with WPF.</Description>

--- a/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
+++ b/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
@@ -7,7 +7,7 @@
     <Description>A .NET Standard, platform-agnostic library for creating cross-platform view-models and applications for various .NET platforms.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
-    <Version>1.5.0</Version>
+    <Version>1.5.1</Version>
     <AssemblyName>BassClefStudio.AppModel</AssemblyName>
   </PropertyGroup>
 

--- a/BassClefStudio.AppModel/Bindings/CollectionBinding.cs
+++ b/BassClefStudio.AppModel/Bindings/CollectionBinding.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Text;
+
+namespace BassClefStudio.AppModel.Bindings
+{
+    /// <summary>
+    /// A wrapper around an existing <see cref="IBinding{T}"/> that provides <see cref="INotifyCollectionChanged"/> change notifications.
+    /// </summary>
+    /// <typeparam name="T">he type of the <see cref="IBinding{T}.CurrentValue"/>.</typeparam>
+    public class CollectionBinding<T> : Binding<T>
+    {
+        /// <summary>
+        /// The base <see cref="IBinding{T}"/> containing the collection to monitor.
+        /// </summary>
+        public IBinding<T> BaseBinding { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="CollectionBinding{T}"/>.
+        /// </summary>
+        /// <param name="baseBinding">The base <see cref="IBinding{T}"/> containing the collection to monitor.</param>
+        public CollectionBinding(IBinding<T> baseBinding)
+        {
+            BaseBinding = baseBinding;
+            BaseBinding.CurrentValueChanged += ParentValueChanged;
+
+            //// Setup the parent's PropertyChanged handler.
+            if (BaseBinding.CurrentValue != null && BaseBinding.CurrentValue is INotifyCollectionChanged notifyBase)
+            {
+                notifyBase.CollectionChanged += ParentCollectionChanged;
+            }
+            oldBase = BaseBinding.CurrentValue;
+
+            UpdateBinding();
+        }
+
+        private T oldBase;
+        private void ParentValueChanged(object sender, EventArgs e)
+        {
+            //// Replace PropertyChanged event handlers and call UpdateBinding().
+            if (oldBase != null && oldBase is INotifyCollectionChanged notifyOldBase)
+            {
+                notifyOldBase.CollectionChanged -= ParentCollectionChanged;
+            }
+            UpdateBinding();
+            if (BaseBinding.CurrentValue != null && BaseBinding.CurrentValue is INotifyCollectionChanged notifyNewBase)
+            {
+                notifyNewBase.CollectionChanged += ParentCollectionChanged;
+            }
+            oldBase = BaseBinding.CurrentValue;
+        }
+
+        private void ParentCollectionChanged(object sender, NotifyCollectionChangedEventArgs e) => TriggerValueChanged();
+
+        /// <inheritdoc/>
+        protected override T GetValue()
+        {
+            return BaseBinding.CurrentValue;
+        }
+
+        /// <inheritdoc/>
+        protected override void SetValue(T newVal)
+        {
+            BaseBinding.CurrentValue = newVal;
+        }
+    }
+}

--- a/BassClefStudio.AppModel/Bindings/ConstantBinding.cs
+++ b/BassClefStudio.AppModel/Bindings/ConstantBinding.cs
@@ -15,14 +15,14 @@ namespace BassClefStudio.AppModel.Bindings
         private T storedValue;
 
         /// <inheritdoc/>
-        public T StoredValue 
+        public T CurrentValue 
         { 
             get => storedValue; 
             set => throw new BindingException("Cannot set the value of a ConstantBinding expression."); 
         }
 
         /// <inheritdoc/>
-        public event EventHandler ValueChanged;
+        public event EventHandler CurrentValueChanged;
 
         /// <summary>
         /// Creates a new <see cref="ConstantBinding{T}"/> with the given value.

--- a/BassClefStudio.AppModel/Bindings/IBinding.cs
+++ b/BassClefStudio.AppModel/Bindings/IBinding.cs
@@ -15,12 +15,12 @@ namespace BassClefStudio.AppModel.Bindings
         /// <summary>
         /// Get or set the currently stored <typeparamref name="T"/> value this <see cref="IBinding{T}"/> represents.
         /// </summary>
-        T StoredValue { get; set; }
+        T CurrentValue { get; set; }
 
         /// <summary>
-        /// An event fired whenever the value of <see cref="StoredValue"/> changes. Equivalent to the <see cref="INotifyPropertyChanged"/> events from the <see cref="StoredValue"/> property.
+        /// An event fired whenever the value of <see cref="CurrentValue"/> changes. Equivalent to the <see cref="INotifyPropertyChanged"/> events from the <see cref="CurrentValue"/> property.
         /// </summary>
-        event EventHandler ValueChanged;
+        event EventHandler CurrentValueChanged;
     }
 
     /// <summary>
@@ -30,14 +30,14 @@ namespace BassClefStudio.AppModel.Bindings
     public abstract class Binding<T> : Observable, IBinding<T>
     {
         /// <summary>
-        /// Backing field for <see cref="Binding{T}"/>'s implementation of the <see cref="StoredValue"/> property.
+        /// Backing field for <see cref="Binding{T}"/>'s implementation of the <see cref="CurrentValue"/> property.
         /// </summary>
-        protected T storedValue;
+        protected T currentValue;
 
         /// <inheritdoc/>
-        public virtual T StoredValue 
+        public virtual T CurrentValue 
         { 
-            get => storedValue;
+            get => currentValue;
             set
             {
                 SetValue(value);
@@ -46,10 +46,10 @@ namespace BassClefStudio.AppModel.Bindings
         }
 
         /// <inheritdoc/>
-        public event EventHandler ValueChanged;
+        public event EventHandler CurrentValueChanged;
 
         /// <summary>
-        /// Gets the current value to update this <see cref="IBinding{T}"/>'s <see cref="StoredValue"/>.
+        /// Gets the current value to update this <see cref="IBinding{T}"/>'s <see cref="CurrentValue"/>.
         /// </summary>
         /// <returns></returns>
         protected abstract T GetValue();
@@ -61,16 +61,25 @@ namespace BassClefStudio.AppModel.Bindings
         protected abstract void SetValue(T newVal);
 
         /// <summary>
-        /// Calling this method causes the <see cref="Binding{T}"/> to update itself, triggering <see cref="ValueChanged"/> and similar events.
+        /// Calling this method causes the <see cref="Binding{T}"/> to update itself, triggering <see cref="CurrentValueChanged"/> and similar events.
         /// </summary>
         public void UpdateBinding()
         {
             var newVal = GetValue();
-            if(newVal == null || !newVal.Equals(StoredValue))
+            if(newVal == null || !newVal.Equals(CurrentValue))
             {
-                Set(ref storedValue, newVal, nameof(StoredValue));
-                ValueChanged?.Invoke(this, new EventArgs());
+                Set(ref currentValue, newVal, nameof(CurrentValue));
+                CurrentValueChanged?.Invoke(this, new EventArgs());
             }
-        }   
+        }
+        
+        /// <summary>
+        /// Triggers the <see cref="CurrentValueChanged"/> and <see cref="INotifyPropertyChanged.PropertyChanged"/> events, even if the value of the <see cref="CurrentValue"/> has not changed.
+        /// </summary>
+        protected void TriggerValueChanged()
+        {
+            Set(ref currentValue, currentValue, nameof(CurrentValue));
+            CurrentValueChanged?.Invoke(this, new EventArgs());
+        }
     }
 }

--- a/BassClefStudio.AppModel/Bindings/PropertyBinding.cs
+++ b/BassClefStudio.AppModel/Bindings/PropertyBinding.cs
@@ -9,7 +9,7 @@ namespace BassClefStudio.AppModel.Bindings
     /// Represents a one-way <see cref="IBinding{T}"/> between a parent object and a property.
     /// </summary>
     /// <typeparam name="TIn">The type of the <see cref="ParentObject"/>.</typeparam>
-    /// <typeparam name="TOut">The type of the <see cref="IBinding{T}.StoredValue"/>.</typeparam>
+    /// <typeparam name="TOut">The type of the <see cref="IBinding{T}.CurrentValue"/>.</typeparam>
     public class PropertyBinding<TIn, TOut> : Binding<TOut>
     {
         /// <summary>
@@ -64,14 +64,14 @@ namespace BassClefStudio.AppModel.Bindings
             PropertyName = propertyName;
             NullAllowed = nullAllowed;
 
-            ParentObject.ValueChanged += ParentValueChanged;
+            ParentObject.CurrentValueChanged += ParentValueChanged;
 
             //// Setup the parent's PropertyChanged handler.
-            if (ParentObject.StoredValue != null && ParentObject.StoredValue is INotifyPropertyChanged notifyParent)
+            if (ParentObject.CurrentValue != null && ParentObject.CurrentValue is INotifyPropertyChanged notifyParent)
             {
                 notifyParent.PropertyChanged += ParentPropertyChanged;
             }
-            oldParent = ParentObject.StoredValue;
+            oldParent = ParentObject.CurrentValue;
 
             UpdateBinding();
         }
@@ -86,11 +86,11 @@ namespace BassClefStudio.AppModel.Bindings
                 notifyOldParent.PropertyChanged -= ParentPropertyChanged;
             }
             UpdateBinding();
-            if(ParentObject.StoredValue != null && ParentObject.StoredValue is INotifyPropertyChanged notifyNewParent)
+            if(ParentObject.CurrentValue != null && ParentObject.CurrentValue is INotifyPropertyChanged notifyNewParent)
             {
                 notifyNewParent.PropertyChanged += ParentPropertyChanged;
             }
-            oldParent = ParentObject.StoredValue;
+            oldParent = ParentObject.CurrentValue;
         }
 
         private void ParentPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -105,9 +105,9 @@ namespace BassClefStudio.AppModel.Bindings
         /// <inheritdoc/>
         protected override TOut GetValue()
         {
-            if(NullAllowed || ParentObject.StoredValue != null)
+            if(NullAllowed || ParentObject.CurrentValue != null)
             {
-                return GetPropertyFunc(ParentObject.StoredValue);
+                return GetPropertyFunc(ParentObject.CurrentValue);
             }
             else
             {
@@ -118,9 +118,9 @@ namespace BassClefStudio.AppModel.Bindings
         /// <inheritdoc/>
         protected override void SetValue(TOut newVal)
         {
-            if (NullAllowed || ParentObject.StoredValue != null)
+            if (NullAllowed || ParentObject.CurrentValue != null)
             {
-                SetPropertyAction(ParentObject.StoredValue, newVal);
+                SetPropertyAction(ParentObject.CurrentValue, newVal);
             }
         }
     }

--- a/BassClefStudio.AppModel/Bindings/SetterBinding.cs
+++ b/BassClefStudio.AppModel/Bindings/SetterBinding.cs
@@ -5,7 +5,7 @@ using System.Text;
 namespace BassClefStudio.AppModel.Bindings
 {
     /// <summary>
-    /// An <see cref="IBinding{T}"/> that is only changed by the setter on <see cref="IBinding{T}.StoredValue"/>.
+    /// An <see cref="IBinding{T}"/> that is only changed by the setter on <see cref="IBinding{T}.CurrentValue"/>.
     /// </summary>
     /// <typeparam name="T">The type of object this <see cref="IBinding{T}"/> represents.</typeparam>
     public class SetterBinding<T> : Binding<T>
@@ -15,24 +15,24 @@ namespace BassClefStudio.AppModel.Bindings
         /// </summary>
         public SetterBinding()
         {
-            storedValue = default(T);
+            currentValue = default(T);
             UpdateBinding();
         }
 
         /// <summary>
         /// Creates a new <see cref="SetterBinding{T}"/> with the given value.
         /// </summary>
-        /// <param name="initialValue">The initial <typeparamref name="T"/> value of the <see cref="IBinding{T}.StoredValue"/>.</param>
+        /// <param name="initialValue">The initial <typeparamref name="T"/> value of the <see cref="IBinding{T}.CurrentValue"/>.</param>
         public SetterBinding(T initialValue)
         {
-            storedValue = initialValue;
+            currentValue = initialValue;
             UpdateBinding();
         }
 
         /// <inheritdoc/>
-        protected override T GetValue() => storedValue;
+        protected override T GetValue() => currentValue;
 
         /// <inheritdoc/>
-        protected override void SetValue(T newVal) => storedValue = newVal;
+        protected override void SetValue(T newVal) => currentValue = newVal;
     }
 }

--- a/BassClefStudio.AppModel/Bindings/TransformBinding.cs
+++ b/BassClefStudio.AppModel/Bindings/TransformBinding.cs
@@ -8,7 +8,7 @@ namespace BassClefStudio.AppModel.Bindings
     /// An <see cref="IBinding{T}"/> expression that can convert to and from two types of objects, backed by an existing <see cref="IBinding{T}"/>.
     /// </summary>
     /// <typeparam name="TIn">The type of the <see cref="InitialBinding"/>.</typeparam>
-    /// <typeparam name="TOut">The type of the <see cref="IBinding{T}.StoredValue"/>.</typeparam>
+    /// <typeparam name="TOut">The type of the <see cref="IBinding{T}.CurrentValue"/>.</typeparam>
     public class TransformBinding<TIn, TOut> : Binding<TOut>
     {
         /// <summary>
@@ -27,7 +27,7 @@ namespace BassClefStudio.AppModel.Bindings
             InitialBinding = initialBinding;
             GetFunc = getFunc;
             SetFunc = setFunc;
-            InitialBinding.ValueChanged += InitialValueChanged;
+            InitialBinding.CurrentValueChanged += InitialValueChanged;
             UpdateBinding();
         }
 
@@ -39,7 +39,7 @@ namespace BassClefStudio.AppModel.Bindings
         public Func<TIn, TOut> GetFunc { get; set; }
 
         /// <inheritdoc/>
-        protected override TOut GetValue() => GetFunc(InitialBinding.StoredValue);
+        protected override TOut GetValue() => GetFunc(InitialBinding.CurrentValue);
 
         /// <summary>
         /// A function that creates a <typeparamref name="TIn"/> from a <typeparamref name="TOut"/>.
@@ -47,6 +47,6 @@ namespace BassClefStudio.AppModel.Bindings
         public Func<TOut, TIn> SetFunc { get; set; }
 
         /// <inheritdoc/>
-        protected override void SetValue(TOut newVal) => InitialBinding.StoredValue = SetFunc(newVal);
+        protected override void SetValue(TOut newVal) => InitialBinding.CurrentValue = SetFunc(newVal);
     }
 }


### PR DESCRIPTION
Renamed some of the beta `IBinding<T>` property and extension method names; created `CollectionBinding<T>` wrapper (see #42).

Also updated version numbers of all AppModel packages to `v1.5.1`.