### PR TITLE
File Copy, Rename, and Move Capabilities

### DIFF
--- a/BassClefStudio.AppModel.Base/BassClefStudio.AppModel.Base.csproj
+++ b/BassClefStudio.AppModel.Base/BassClefStudio.AppModel.Base.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>BassClefStudio</Authors>
-    <Version>1.7.0</Version>
+    <Version>1.7.1</Version>
     <Description>Services and classes for the BassClefStudio.AppModel library that provide basic features for cross-platform MVVM applications running on .NET Standard.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>

--- a/BassClefStudio.AppModel.Base/Storage/BaseFile.cs
+++ b/BassClefStudio.AppModel.Base/Storage/BaseFile.cs
@@ -63,15 +63,28 @@ namespace BassClefStudio.AppModel.Storage
             File.Delete();
         }
 
+        /// <inheritdoc/>
+        public async Task RenameAsync(string desiredName)
+        {
+            await this.MoveToAsync(
+                new BaseFolder(new DirectoryInfo(Path.GetDirectoryName(File.FullName))),
+                CollisionOptions.FailIfExists,
+                desiredName);
+        }
+
+        /// <inheritdoc/>
         public static bool operator ==(BaseFile a, BaseFile b) => a.File == b.File;
+        /// <inheritdoc/>
         public static bool operator !=(BaseFile a, BaseFile b) => !(a == b);
 
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             return obj is BaseFile file
                 && this == file;
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return base.GetHashCode();

--- a/BassClefStudio.AppModel.Base/Storage/BaseFolder.cs
+++ b/BassClefStudio.AppModel.Base/Storage/BaseFolder.cs
@@ -149,5 +149,32 @@ namespace BassClefStudio.AppModel.Storage
         {
             Directory.Delete(true);
         }
+
+        /// <inheritdoc/>
+        public async Task RenameAsync(string desiredName)
+        {
+            await this.MoveToAsync(
+                new BaseFolder(new DirectoryInfo(Path.GetDirectoryName(Directory.FullName))),
+                CollisionOptions.FailIfExists,
+                desiredName);
+        }
+
+        /// <inheritdoc/>
+        public static bool operator ==(BaseFolder a, BaseFolder b) => a.Directory == b.Directory;
+        /// <inheritdoc/>
+        public static bool operator !=(BaseFolder a, BaseFolder b) => !(a == b);
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            return obj is BaseFolder folder
+                && this == folder;
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
     }
 }

--- a/BassClefStudio.AppModel.Blazor/BassClefStudio.AppModel.Blazor.csproj
+++ b/BassClefStudio.AppModel.Blazor/BassClefStudio.AppModel.Blazor.csproj
@@ -5,7 +5,7 @@
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications on .NET 5 with Blazor.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
-    <Version>1.7.0</Version>
+    <Version>1.7.1</Version>
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/BassClefStudio.AppModel.Console/BassClefStudio.AppModel.Console.csproj
+++ b/BassClefStudio.AppModel.Console/BassClefStudio.AppModel.Console.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
-    <Version>1.7.0</Version>
+    <Version>1.7.1</Version>
     <Authors>BassClefStudio</Authors>
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications in .NET Console applications.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>

--- a/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
+++ b/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>BassClefStudio.AppModel.Uwp</id>
-    <version>1.7.0</version>
+    <version>1.7.1</version>
     <title>BassClefStudio.AppModel.Uwp</title>
     <authors>BassClefStudio</authors>
     <owners>BassClefStudio</owners>

--- a/BassClefStudio.AppModel.Uwp/Storage/UwpFile.cs
+++ b/BassClefStudio.AppModel.Uwp/Storage/UwpFile.cs
@@ -48,15 +48,32 @@ namespace BassClefStudio.AppModel.Storage
             await File.DeleteAsync();
         }
 
+        /// <inheritdoc/>
+        public async Task RenameAsync(string desiredName)
+        {
+            try
+            {
+                await File.RenameAsync(desiredName, NameCollisionOption.FailIfExists);
+            }
+            catch(Exception ex)
+            {
+                throw new StorageConflictException($"\"{File.Path}\" could not be renamed to {desiredName} because a file of that name already exists.", ex);
+            }
+        }
+
+        /// <inheritdoc/>
         public static bool operator ==(UwpFile a, UwpFile b) => a.File == b.File;
+        /// <inheritdoc/>
         public static bool operator !=(UwpFile a, UwpFile b) => !(a == b);
 
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             return obj is UwpFile file
                 && this == file;
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return base.GetHashCode();

--- a/BassClefStudio.AppModel.Uwp/Storage/UwpFolder.cs
+++ b/BassClefStudio.AppModel.Uwp/Storage/UwpFolder.cs
@@ -70,5 +70,36 @@ namespace BassClefStudio.AppModel.Storage
         {
             await Folder.DeleteAsync();
         }
+
+        /// <inheritdoc/>
+        public async Task RenameAsync(string desiredName)
+        {
+            try
+            {
+                await Folder.RenameAsync(desiredName, NameCollisionOption.FailIfExists);
+            }
+            catch (Exception ex)
+            {
+                throw new StorageConflictException($"\"{Folder.Path}\" could not be renamed to {desiredName} because a file of that name already exists.", ex);
+            }
+        }
+
+        /// <inheritdoc/>
+        public static bool operator ==(UwpFolder a, UwpFolder b) => a.Folder == b.Folder;
+        /// <inheritdoc/>
+        public static bool operator !=(UwpFolder a, UwpFolder b) => !(a == b);
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            return obj is UwpFolder folder
+                && this == folder;
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
     }
 }

--- a/BassClefStudio.AppModel.Wpf/BassClefStudio.AppModel.Wpf.csproj
+++ b/BassClefStudio.AppModel.Wpf/BassClefStudio.AppModel.Wpf.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Authors>BassClefStudio</Authors>
-    <Version>1.7.0</Version>
+    <Version>1.7.1</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications on .NET 5 with WPF.</Description>

--- a/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
+++ b/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
@@ -7,7 +7,7 @@
     <Description>A .NET Standard, platform-agnostic library for creating cross-platform view-models and applications for various .NET platforms.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
-    <Version>1.7.0</Version>
+    <Version>1.7.1</Version>
     <AssemblyName>BassClefStudio.AppModel</AssemblyName>
   </PropertyGroup>
 

--- a/BassClefStudio.AppModel/Storage/IStorageFolder.cs
+++ b/BassClefStudio.AppModel/Storage/IStorageFolder.cs
@@ -13,6 +13,7 @@ namespace BassClefStudio.AppModel.Storage
         /// <summary>
         /// Gets all of the child items of this folder.
         /// </summary>
+        /// <exception cref="StorageAccessException">An error occurred accessing the backend data for the file.</exception>
         /// <returns>An <see cref="IEnumerable{T}"/> of each <see cref="IStorageItem"/> child of the <see cref="IStorageFolder"/>.</returns>
         Task<IEnumerable<IStorageItem>> GetItemsAsync();
 
@@ -20,6 +21,7 @@ namespace BassClefStudio.AppModel.Storage
         /// Gets the child folder in this folder with the given path.
         /// </summary>
         /// <param name="relativePath">The <see cref="string"/> path to the item, relative to this <see cref="IStorageFolder"/>.</param>
+        /// <exception cref="StorageAccessException">An error occurred accessing the backend data for the file.</exception>
         /// <returns>The child <see cref="IStorageFolder"/> at the given path.</returns>
         Task<IStorageFolder> GetFolderAsync(string relativePath);
 
@@ -27,6 +29,7 @@ namespace BassClefStudio.AppModel.Storage
         /// Gets the child file in this folder with the given path.
         /// </summary>
         /// <param name="relativePath">The <see cref="string"/> path to the item, relative to this <see cref="IStorageFolder"/>.</param>
+        /// <exception cref="StorageAccessException">An error occurred accessing the backend data for the file.</exception>
         /// <returns>The child <see cref="IStorageFile"/> at the given path.</returns>
         Task<IStorageFile> GetFileAsync(string relativePath);
 
@@ -35,6 +38,8 @@ namespace BassClefStudio.AppModel.Storage
         /// </summary>
         /// <param name="name">The name of the new file, including its file extension.</param>
         /// <param name="options">A <see cref="CollisionOptions"/> value indicating the action to take if the file exists.</param>
+        /// <exception cref="StorageAccessException">An error occurred accessing the backend data for the file.</exception>
+        /// <exception cref="StorageConflictException">A file with the given <paramref name="name"/> exists, and the <paramref name="options"/> did not provide a way to handle the conflict.</exception>
         /// <returns>The newly created file.</returns>
         Task<IStorageFile> CreateFileAsync(string name, CollisionOptions options = CollisionOptions.OpenExisting);
 
@@ -43,6 +48,8 @@ namespace BassClefStudio.AppModel.Storage
         /// </summary>
         /// <param name="name">The name of the new folder.</param>
         /// <param name="options">A <see cref="CollisionOptions"/> value indicating the action to take if the file exists.</param>
+        /// <exception cref="StorageAccessException">An error occurred accessing the backend data for the file.</exception>
+        /// <exception cref="StorageConflictException">A folder with the given <paramref name="name"/> exists, and the <paramref name="options"/> did not provide a way to handle the conflict.</exception>
         /// <returns>The newly created folder.</returns>
         Task<IStorageFolder> CreateFolderAsync(string name, CollisionOptions options = CollisionOptions.OpenExisting);
     }

--- a/BassClefStudio.AppModel/Storage/IStorageItem.cs
+++ b/BassClefStudio.AppModel/Storage/IStorageItem.cs
@@ -19,5 +19,12 @@ namespace BassClefStudio.AppModel.Storage
         /// Deletes the <see cref="IStorageItem"/> from the filesystem.
         /// </summary>
         Task RemoveAsync();
+
+        /// <summary>
+        /// Renames the existing file to the desired <see cref="Name"/>, or fails if renaming cannot complete.
+        /// </summary>
+        /// <param name="desiredName">The desired <see cref="string"/> name (including extension, if applicable) of the <see cref="IStorageItem"/>.</param>
+        /// <exception cref="StorageConflictException">The <paramref name="desiredName"/> is already used in the parent directory.</exception>
+        Task RenameAsync(string desiredName);
     }
 }

--- a/BassClefStudio.AppModel/Storage/StorageExceptions.cs
+++ b/BassClefStudio.AppModel/Storage/StorageExceptions.cs
@@ -39,4 +39,22 @@ namespace BassClefStudio.AppModel.Storage
           System.Runtime.Serialization.SerializationInfo info,
           System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
+
+    /// <summary>
+    /// An <see cref="Exception"/> thrown when an action on an <see cref="IStorageItem"/> conflicts with an existing file or directory.
+    /// </summary>
+    [Serializable]
+    public class StorageConflictException : Exception
+    {
+        /// <inheritdoc/>
+        public StorageConflictException() { }
+        /// <inheritdoc/>
+        public StorageConflictException(string message) : base(message) { }
+        /// <inheritdoc/>
+        public StorageConflictException(string message, Exception inner) : base(message, inner) { }
+        /// <inheritdoc/>
+        protected StorageConflictException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
 }

--- a/BassClefStudio.AppModel/Storage/StorageExtensions.cs
+++ b/BassClefStudio.AppModel/Storage/StorageExtensions.cs
@@ -32,6 +32,8 @@ namespace BassClefStudio.AppModel.Storage
             return allItems.Any(i => i.Name == name);
         }
 
+        #region Copy and Move
+
         /// <summary>
         /// Copies the contents of the given <see cref="IStorageFile"/> into a new file located in the specified <see cref="IStorageFolder"/>.
         /// </summary>
@@ -126,7 +128,13 @@ namespace BassClefStudio.AppModel.Storage
                 {
                     await dir.CopyToAsync(destination, CollisionOptions.FailIfExists);
                 }
+                else
+                {
+                    throw new StorageAccessException($"Attempted to copy an item that was neither a file or folder. Type \"{item?.GetType().Name}\"");
+                }
             }
         }
+
+        #endregion
     }
 }

--- a/BassClefStudio.AppModel/Storage/StorageExtensions.cs
+++ b/BassClefStudio.AppModel/Storage/StorageExtensions.cs
@@ -31,5 +31,102 @@ namespace BassClefStudio.AppModel.Storage
             var allItems = await folder.GetItemsAsync();
             return allItems.Any(i => i.Name == name);
         }
+
+        /// <summary>
+        /// Copies the contents of the given <see cref="IStorageFile"/> into a new file located in the specified <see cref="IStorageFolder"/>.
+        /// </summary>
+        /// <param name="file">The existing file whose contents should be read.</param>
+        /// <param name="destination">The destination folder to copy the <see cref="IStorageFile"/> into.</param>
+        /// <param name="collisionOptions">Overrides the <see cref="CollisionOptions"/> behavior when creating the new file in the <paramref name="destination"/> folder.</param>
+        /// <param name="fileName">Overrides the name of the destination file (default is <see cref="IStorageItem.Name"/> of the source <paramref name="file"/>).</param>
+        public static async Task CopyToAsync(this IStorageFile file, IStorageFolder destination, CollisionOptions collisionOptions = CollisionOptions.RenameIfExists, string fileName = null)
+        {
+            IStorageFile destinationFile = await destination.CreateFileAsync(fileName ?? file.Name, collisionOptions);
+            await CopyContentsAsync(file, destinationFile);
+        }
+
+        /// <summary>
+        /// Copies the contents of the given <see cref="IStorageFile"/> into a new file located in the specified <see cref="IStorageFolder"/>, and then removes the source file.
+        /// </summary>
+        /// <param name="file">The existing file whose contents should be read.</param>
+        /// <param name="destination">The destination folder to copy the <see cref="IStorageFile"/> into.</param>
+        /// <param name="collisionOptions">Overrides the <see cref="CollisionOptions"/> behavior when creating the new file in the <paramref name="destination"/> folder.</param>
+        /// <param name="fileName">Overrides the name of the destination file (default is <see cref="IStorageItem.Name"/> of the source <paramref name="file"/>).</param>
+        public static async Task MoveToAsync(this IStorageFile file, IStorageFolder destination, CollisionOptions collisionOptions = CollisionOptions.RenameIfExists, string fileName = null)
+        {
+            IStorageFile destinationFile = await destination.CreateFileAsync(fileName ?? file.Name, collisionOptions);
+            await CopyContentsAsync(file, destinationFile);
+            await file.RemoveAsync();
+        }
+
+        /// <summary>
+        /// Copies the contents of the given <see cref="IStorageFile"/> into the provided new <see cref="IStorageFile"/>.
+        /// </summary>
+        /// <param name="file">The existing file whose contents should be read.</param>
+        /// <param name="destination">A new, empty file with write access, where the contents of <paramref name="file"/> will be copied.</param>
+        public static async Task CopyContentsAsync(this IStorageFile file, IStorageFile destination)
+        {
+            using (var readFile = await file.OpenFileAsync(FileOpenMode.Read))
+            {
+                using (var readStream = readFile.GetReadStream())
+                {
+                    using (var writeFile = await destination.OpenFileAsync(FileOpenMode.ReadWrite))
+                    {
+                        using (var writeStream = writeFile.GetWriteStream())
+                        {
+                            await readStream.CopyToAsync(writeStream);
+                            await writeStream.FlushAsync();
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Copies the contents of the given <see cref="IStorageFile"/> into a new folder located in the specified <see cref="IStorageFolder"/>.
+        /// </summary>
+        /// <param name="folder">The existing file whose contents should be read.</param>
+        /// <param name="destination">The destination folder to copy the <see cref="IStorageFile"/> into.</param>
+        /// <param name="collisionOptions">Overrides the <see cref="CollisionOptions"/> behavior when creating the new file in the <paramref name="destination"/> folder.</param>
+        /// <param name="folderName">Overrides the name of the destination file (default is <see cref="IStorageItem.Name"/> of the source <paramref name="folder"/>).</param>
+        public static async Task CopyToAsync(this IStorageFolder folder, IStorageFolder destination, CollisionOptions collisionOptions = CollisionOptions.RenameIfExists, string folderName = null)
+        {
+            IStorageFolder destinationFolder = await destination.CreateFolderAsync(folderName ?? folder.Name, collisionOptions);
+            await CopyContentsAsync(folder, destinationFolder);
+        }
+
+        /// <summary>
+        /// Copies the contents of the given <see cref="IStorageFolder"/> into a new folder located in the specified <see cref="IStorageFolder"/>, and then removes the source folder.
+        /// </summary>
+        /// <param name="folder">The existing folder whose contents should be read.</param>
+        /// <param name="destination">The destination folder to copy the <see cref="IStorageFile"/> into.</param>
+        /// <param name="collisionOptions">Overrides the <see cref="CollisionOptions"/> behavior when creating the new file in the <paramref name="destination"/> folder.</param>
+        /// <param name="folderName">Overrides the name of the destination file (default is <see cref="IStorageItem.Name"/> of the source <paramref name="folder"/>).</param>
+        public static async Task MoveToAsync(this IStorageFolder folder, IStorageFolder destination, CollisionOptions collisionOptions = CollisionOptions.RenameIfExists, string folderName = null)
+        {
+            IStorageFolder destinationFolder = await destination.CreateFolderAsync(folderName ?? folder.Name, collisionOptions);
+            await CopyContentsAsync(folder, destinationFolder);
+            await folder.RemoveAsync();
+        }
+
+        /// <summary>
+        /// Copies the contents of the given <see cref="IStorageFolder"/> into the provided new <see cref="IStorageFolder"/>.
+        /// </summary>
+        /// <param name="folder">The existing folder whose contents should be read.</param>
+        /// <param name="destination">A new, empty folder with write access, where the contents of <paramref name="folder"/> will be copied.</param>
+        public static async Task CopyContentsAsync(this IStorageFolder folder, IStorageFolder destination)
+        {
+            foreach(var item in await folder.GetItemsAsync())
+            {
+                if(item is IStorageFile file)
+                {
+                    await file.CopyToAsync(destination, CollisionOptions.FailIfExists);
+                }
+                else if(item is IStorageFolder dir)
+                {
+                    await dir.CopyToAsync(destination, CollisionOptions.FailIfExists);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #51 by addressing all remaining `IStorage` API improvements there. `IStorageItem`s can now be renamed, while `IStorageFile` and `IStorageFolder` (as well as all implementations) support copying of contents, copying to a new folder, and moving files and folders. Copying and moving are all implemented in extension methods, meaning that these changes fully support the creation of other non-native filesystems (see #53).