### PR TITLE
App Contexts, Better Debugging

### DIFF
--- a/BassClefStudio.AppModel.Base/BassClefStudio.AppModel.Base.csproj
+++ b/BassClefStudio.AppModel.Base/BassClefStudio.AppModel.Base.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>BassClefStudio</Authors>
-    <Version>1.8.0</Version>
+    <Version>1.8.1</Version>
     <Description>Services and classes for the BassClefStudio.AppModel library that provide basic features for cross-platform MVVM applications running on .NET Standard.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>

--- a/BassClefStudio.AppModel.Blazor/BassClefStudio.AppModel.Blazor.csproj
+++ b/BassClefStudio.AppModel.Blazor/BassClefStudio.AppModel.Blazor.csproj
@@ -5,7 +5,7 @@
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications on .NET 5 with Blazor.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
-    <Version>1.8.0</Version>
+    <Version>1.8.1</Version>
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/BassClefStudio.AppModel.Console/BassClefStudio.AppModel.Console.csproj
+++ b/BassClefStudio.AppModel.Console/BassClefStudio.AppModel.Console.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
-    <Version>1.8.0</Version>
+    <Version>1.8.1</Version>
     <Authors>BassClefStudio</Authors>
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications in .NET Console applications.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>

--- a/BassClefStudio.AppModel.Console/Lifecycle/ConsoleAppPlatform.cs
+++ b/BassClefStudio.AppModel.Console/Lifecycle/ConsoleAppPlatform.cs
@@ -18,8 +18,8 @@ namespace BassClefStudio.AppModel.Lifecycle
         public void ConfigureServices(ContainerBuilder builder)
         {
             builder.RegisterType<ConsoleNavigationService>()
-                .SingleInstance()
-                .AsImplementedInterfaces();
+                .AsImplementedInterfaces()
+                .SingleInstance();
             //builder.RegisterType<ConsoleBackgroundService>()
             //    .SingleInstance()
             //    .AsImplementedInterfaces();

--- a/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
+++ b/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>BassClefStudio.AppModel.Uwp</id>
-    <version>1.8.0</version>
+    <version>1.8.1</version>
     <title>BassClefStudio.AppModel.Uwp</title>
     <authors>BassClefStudio</authors>
     <owners>BassClefStudio</owners>
@@ -12,7 +12,7 @@
     <dependencies>
       <group targetFramework="uap10.0.17763">
         <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.2.10"/>
-        <dependency id="BassClefStudio.AppModel" version="1.8.0"/>
+        <dependency id="BassClefStudio.AppModel" version="1.8.1"/>
         <dependency id="Microsoft.Toolkit.Uwp.Notifications" version="7.0.0"/>
       </group>
     </dependencies>

--- a/BassClefStudio.AppModel.Wpf/BassClefStudio.AppModel.Wpf.csproj
+++ b/BassClefStudio.AppModel.Wpf/BassClefStudio.AppModel.Wpf.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Authors>BassClefStudio</Authors>
-    <Version>1.8.0</Version>
+    <Version>1.8.1</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications on .NET 5 with WPF.</Description>

--- a/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
+++ b/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.1.0" />
     <PackageReference Include="BassClefStudio.NET.Core" Version="1.5.4" />
-    <PackageReference Include="BassClefStudio.NET.Sync" Version="1.5.2" />
+    <PackageReference Include="BassClefStudio.NET.Sync" Version="1.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 </Project>

--- a/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
+++ b/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.1.0" />
     <PackageReference Include="BassClefStudio.NET.Core" Version="1.5.4" />
+    <PackageReference Include="BassClefStudio.NET.Sync" Version="1.5.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 </Project>

--- a/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
+++ b/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
@@ -7,7 +7,7 @@
     <Description>A .NET Standard, platform-agnostic library for creating cross-platform view-models and applications for various .NET platforms.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
-    <Version>1.8.0</Version>
+    <Version>1.8.1</Version>
     <AssemblyName>BassClefStudio.AppModel</AssemblyName>
   </PropertyGroup>
 

--- a/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
+++ b/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.1.0" />
     <PackageReference Include="BassClefStudio.NET.Core" Version="1.5.4" />
+    <PackageReference Include="BassClefStudio.NET.Serialization" Version="2.2.5" />
     <PackageReference Include="BassClefStudio.NET.Sync" Version="1.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>

--- a/BassClefStudio.AppModel/Helpers/SettingsContexts.cs
+++ b/BassClefStudio.AppModel/Helpers/SettingsContexts.cs
@@ -1,0 +1,101 @@
+﻿using Autofac;
+using BassClefStudio.AppModel.Settings;
+using BassClefStudio.NET.Serialization;
+using BassClefStudio.NET.Sync;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BassClefStudio.AppModel.Helpers
+{
+    /// <summary>
+    /// An <see cref="ILink{T}"/> that provides a means for getting and storing data in the <see cref="ISettingsService"/> store.
+    /// </summary>
+    /// <typeparam name="T">The type of objects that this <see cref="ILink{T}"/> handles.</typeparam>
+    public class SettingsLink<T> : ILink<T>
+    {
+        /// <summary>
+        /// The <see cref="string"/> key or path to the place where the <typeparamref name="T"/> item should be stored.
+        /// </summary>
+        public string Key { get; set; }
+
+        /// <summary>
+        /// A <see cref="bool"/> indicating whether the <see cref="SettingsLink{T}"/> is configured to use an <see cref="BassClefStudio.NET.Serialization.ISerializationService"/> for serialization of the given <typeparamref name="T"/> values.
+        /// </summary>
+        public bool UseSerializer { get; }
+
+        internal ISettingsService SettingsService { get; }
+        internal ISerializationService SerializationService { get; }
+        /// <summary>
+        /// Creates a new <see cref="SettingsLink{T}"/> from the required services.
+        /// </summary>
+        public SettingsLink(ISettingsService settingsService)
+        {
+            SettingsService = settingsService;
+            UseSerializer = false;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="SettingsLink{T}"/> from the required services and optional <see cref="ISerializationService"/>.
+        /// </summary>
+        public SettingsLink(ISettingsService settingsService, ISerializationService serializationService)
+        {
+            SettingsService = settingsService;
+            SerializationService = serializationService;
+            UseSerializer = SerializationService.IsSerializable<T>();
+        }
+
+        /// <inheritdoc/>
+        public async Task PushAsync(ISyncItem<T> item)
+        {
+            if (UseSerializer)
+            {
+                string json = SerializationService.Serialize(item.Item);
+                await SettingsService.SetValueAsync(Key, json);
+            }
+            else
+            {
+                await SettingsService.SetValueAsync(Key, item.Item);
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task UpdateAsync(ISyncItem<T> item)
+        {
+            if (UseSerializer)
+            {
+                string json = await SettingsService.GetValueAsync<string>(Key);
+                item.Item = SerializationService.Deserialize<T>(json);
+            }
+            else
+            {
+                item.Item = await SettingsService.GetValueAsync<T>(Key);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Provides extension methods for registering <see cref="ISyncItem{T}"/>s to the DI container that are linked using <see cref="SettingsLink{T}"/> to a location in the settings store.
+    /// </summary>
+    public static class SettingsLinkExtensions
+    {
+        /// <summary>
+        /// Registers <see cref="ISyncItem{T}"/> of the specified type <typeparamref name="T"/> to return a <see cref="SyncItem{T}"/> that is connected to the backing store of a specific location in settings using a <see cref="SettingsLink{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the context to provide. Generally, there should only be one declaration of this type of <see cref="ISyncItem{T}"/> per application.</typeparam>
+        /// <param name="builder">The <see cref="ContainerBuilder"/> to add services to.</param>
+        /// <param name="settingsKey">The <see cref="string"/> key or 'path' to the location in settings where the <typeparamref name="T"/> object should be stored.</param>
+        public static void RegisterSettingsContext<T>(this ContainerBuilder builder, string settingsKey)
+        {
+            builder.RegisterType<SettingsLink<T>>()
+                .WithProperty("Key", settingsKey)
+                .Keyed<ILink<T>>($"Setting-{settingsKey}")
+                .AsImplementedInterfaces();
+            builder.RegisterType<SyncItem<T>>()
+                .WithParameter(Autofac.Core.ResolvedParameter.ForKeyed<ILink<T>>($"Setting-{settingsKey}"))
+                .AsImplementedInterfaces()
+                .SingleInstance();
+        }
+    }
+}

--- a/BassClefStudio.AppModel/Lifecycle/App.cs
+++ b/BassClefStudio.AppModel/Lifecycle/App.cs
@@ -82,8 +82,15 @@ namespace BassClefStudio.AppModel.Lifecycle
         public void SetupContainer(ContainerBuilder builder, IAppPlatform platform, params Assembly[] assemblies)
         {
             platform.ConfigureServices(builder);
+            //// Register any internal services that deal with lifecycle of the app.
+            builder.RegisterAssemblyTypes(typeof(App).Assembly)
+                .AssignableTo<ILifecycleHandler>()
+                .AsImplementedInterfaces();
+            //// Register any IPlatformModules as both modules and types 
             builder.RegisterAssemblyModules<IPlatformModule>(assemblies);
-            builder.RegisterAssemblyTypes(assemblies).AssignableTo<IPlatformModule>();
+            builder.RegisterAssemblyTypes(assemblies)
+                .AssignableTo<IPlatformModule>()
+                .SingleInstance();
             this.ConfigureServices(builder);
             //// Resister this app instance to all view-models, etc.
             builder.RegisterInstance<App>(this);
@@ -97,11 +104,11 @@ namespace BassClefStudio.AppModel.Lifecycle
         /// </summary>
         public void RunInitMethods()
         {
-            //// Declare the loaded IPlatformModules
             var modules = Services.Resolve<IEnumerable<IPlatformModule>>();
-            foreach(var mod in modules)
+            //// Declare the loaded IPlatformModules
+            foreach (var mod in modules)
             {
-                Debug.WriteLine($"AppModel: Loaded module \"{mod.Name}\"");
+                Debug.WriteLine($"AppModel: Found module \"{mod.Name}\"");
             }
 
             //// Run any IInitializationHandlers.


### PR DESCRIPTION
`App.cs` now provides better debugging messages, especially for `IPlatformModule`s that it loads on initialization.

In addition, this PR allows for the creation of `ISyncItem<T>`-based app contexts, which can load data from settings. These sync-able items (powered by [BassClefStudio.NET.Sync](https://github.com/bassclefstudio/.NET-Libraries)) can be added to the DI container using a simple extension method.