### PR TITLE
Documentation improvements, PropertiesAutowired() calls to DI registrations for view-models.

### DIFF
--- a/BassClefStudio.AppModel.Base/BassClefStudio.AppModel.Base.csproj
+++ b/BassClefStudio.AppModel.Base/BassClefStudio.AppModel.Base.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>BassClefStudio</Authors>
-    <Version>1.8.2</Version>
+    <Version>1.8.4</Version>
     <Description>Services and classes for the BassClefStudio.AppModel library that provide basic features for cross-platform MVVM applications running on .NET Standard.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>

--- a/BassClefStudio.AppModel.Blazor/BassClefStudio.AppModel.Blazor.csproj
+++ b/BassClefStudio.AppModel.Blazor/BassClefStudio.AppModel.Blazor.csproj
@@ -5,7 +5,7 @@
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications on .NET 5 with Blazor.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
-    <Version>1.8.2</Version>
+    <Version>1.8.4</Version>
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/BassClefStudio.AppModel.Console/BassClefStudio.AppModel.Console.csproj
+++ b/BassClefStudio.AppModel.Console/BassClefStudio.AppModel.Console.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
-    <Version>1.8.2</Version>
+    <Version>1.8.4</Version>
     <Authors>BassClefStudio</Authors>
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications in .NET Console applications.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>

--- a/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
+++ b/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>BassClefStudio.AppModel.Uwp</id>
-    <version>1.8.2</version>
+    <version>1.8.4</version>
     <title>BassClefStudio.AppModel.Uwp</title>
     <authors>BassClefStudio</authors>
     <owners>BassClefStudio</owners>
@@ -12,7 +12,7 @@
     <dependencies>
       <group targetFramework="uap10.0.17763">
         <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.2.10"/>
-        <dependency id="BassClefStudio.AppModel" version="1.8.2"/>
+        <dependency id="BassClefStudio.AppModel" version="1.8.4"/>
         <dependency id="Microsoft.Toolkit.Uwp.Notifications" version="7.0.0"/>
       </group>
     </dependencies>

--- a/BassClefStudio.AppModel.Wpf/BassClefStudio.AppModel.Wpf.csproj
+++ b/BassClefStudio.AppModel.Wpf/BassClefStudio.AppModel.Wpf.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Authors>BassClefStudio</Authors>
-    <Version>1.8.2</Version>
+    <Version>1.8.4</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications on .NET 5 with WPF.</Description>

--- a/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
+++ b/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
@@ -7,15 +7,15 @@
     <Description>A .NET Standard, platform-agnostic library for creating cross-platform view-models and applications for various .NET platforms.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
-    <Version>1.8.3</Version>
+    <Version>1.8.4</Version>
     <AssemblyName>BassClefStudio.AppModel</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.1.0" />
     <PackageReference Include="BassClefStudio.NET.Core" Version="1.5.4" />
-    <PackageReference Include="BassClefStudio.NET.Serialization" Version="2.2.5" />
+    <PackageReference Include="BassClefStudio.NET.Serialization" Version="2.2.7" />
     <PackageReference Include="BassClefStudio.NET.Sync" Version="1.6.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 </Project>

--- a/BassClefStudio.AppModel/Helpers/StorageContexts.cs
+++ b/BassClefStudio.AppModel/Helpers/StorageContexts.cs
@@ -26,7 +26,7 @@ namespace BassClefStudio.AppModel.Helpers
         internal IDispatcherService DispatcherService { get; }
         internal ISerializationService SerializationService { get; }
         /// <summary>
-        /// Creates a new <see cref="SettingsLink{T}"/> from the required services.
+        /// Creates a new <see cref="StorageLink{T}"/> from the required services.
         /// </summary>
         public StorageLink(IStorageService storageService, IDispatcherService dispatcherService, ISerializationService serializationService)
         {
@@ -56,7 +56,7 @@ namespace BassClefStudio.AppModel.Helpers
     }
 
     /// <summary>
-    /// Provides extension methods for registering <see cref="ISyncItem{T}"/>s to the DI container that are linked using <see cref="SettingsLink{T}"/> to a location in the settings store.
+    /// Provides extension methods for registering <see cref="ISyncItem{T}"/>s to the DI container that are linked using <see cref="StorageLink{T}"/> to a specific location in the app data folder.
     /// </summary>
     public static class StorageLinkExtensions
     {

--- a/BassClefStudio.AppModel/Lifecycle/App.cs
+++ b/BassClefStudio.AppModel/Lifecycle/App.cs
@@ -370,10 +370,12 @@ namespace BassClefStudio.AppModel.Lifecycle
         public static void RegisterViewModels(this ContainerBuilder builder, params Assembly[] assemblies)
         {
             builder.RegisterAssemblyTypes(assemblies)
-                .AssignableTo<IViewModel>();
+                .AssignableTo<IViewModel>()
+                .PropertiesAutowired();
             builder.RegisterAssemblyTypes(assemblies)
                 .AssignableTo<IViewModel>()
-                .AsImplementedInterfaces();
+                .AsImplementedInterfaces()
+                .PropertiesAutowired();
         }
 
         /// <summary>

--- a/BassClefStudio.AppModel/Storage/IStorageProvider.cs
+++ b/BassClefStudio.AppModel/Storage/IStorageProvider.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BassClefStudio.AppModel.Storage
+{
+    /// <summary>
+    /// Represents a service that can provide an external (i.e. not the default file-system) implementation of <see cref="IStorageItem"/> objects and navigate a collection of files and folders.
+    /// </summary>
+    public interface IStorageProvider
+    {
+        /// <summary>
+        /// A <see cref="bool"/> indicating whether the <see cref="IStorageProvider"/> has been initialized (see <see cref="InitializeAsync"/>).
+        /// </summary>
+        bool Initialized { get; }
+
+        /// <summary>
+        /// Attempts to asynchronously initialize the external filesystem this <see cref="IStorageProvider"/> provides.
+        /// </summary>
+        /// <returns>A <see cref="bool"/> indicating whether the operation succeeded.</returns>
+        Task<bool> InitializeAsync();
+
+        /// <summary>
+        /// Asynchronously returns the root node of the filesystem, as an <see cref="IStorageFolder"/>.
+        /// </summary>
+        /// <returns>An <see cref="IStorageFolder"/> which may or may not be an actual folder, but which contains the contents of the <see cref="IStorageProvider"/>'s filesystem.</returns>
+        Task<IStorageFolder> GetRootAsync();
+    }
+}


### PR DESCRIPTION
`IViewModel`s can be initialized by simply establishing get/set public properties that will have services (e.g. `IStorageService`) injected by the DI container on initialization. Closes #62.