### PR TITLE
Back navigation fixes

### DIFF
--- a/BassClefStudio.AppModel.Base/BassClefStudio.AppModel.Base.csproj
+++ b/BassClefStudio.AppModel.Base/BassClefStudio.AppModel.Base.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>BassClefStudio</Authors>
-    <Version>1.8.6</Version>
+    <Version>1.9.0</Version>
     <Description>Services and classes for the BassClefStudio.AppModel library that provide basic features for cross-platform MVVM applications running on .NET Standard.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>

--- a/BassClefStudio.AppModel.Blazor/Navigation/BlazorNavigationService.cs
+++ b/BassClefStudio.AppModel.Blazor/Navigation/BlazorNavigationService.cs
@@ -11,10 +11,10 @@ namespace BassClefStudio.AppModel.Navigation
     /// <summary>
     /// Represents a <see cref="BlazorNavigationService"/> that navigates to URLs in the Blazor SPA and provides the current view information for components to retrieve their <see cref="IViewModel"/>.
     /// </summary>
-    public class BlazorNavigationService : INavigationService
+    public class BlazorNavigationService : NavigationService<BlazorView>, INavigationService
     {
-        internal IBlazorViewProvider ViewProvider { get; }
-        internal NavigationManager NavigationManager { get; }
+        private IBlazorViewProvider ViewProvider { get; }
+        private NavigationManager NavigationManager { get; }
         /// <summary>
         /// Creates a new <see cref="BlazorNavigationService"/> from the required Blazor dependencies.
         /// </summary>
@@ -27,22 +27,15 @@ namespace BassClefStudio.AppModel.Navigation
         }
 
         /// <inheritdoc/>
-        public void InitializeNavigation()
+        public override void InitializeNavigation()
         { }
 
         /// <inheritdoc/>
-        public void Navigate(IView view)
+        protected override void NavigateInternal(BlazorView view)
         {
-            Console.WriteLine($"Navigate {view}.");
-            if(view is BlazorView blazorView)
-            {
-                ViewProvider.CurrentView = blazorView;
-                NavigationManager.NavigateTo($"{NavigationManager.BaseUri}{blazorView.ViewPath}");
-            }
-            else
-            {
-                Debug.WriteLine("Blazor navigation expects a BlazorView IView instance.");
-            }
+            Console.WriteLine($"Navigate {view.ViewPath}.");
+            ViewProvider.CurrentView = view;
+            NavigationManager.NavigateTo($"{NavigationManager.BaseUri}{view.ViewPath}");
         }
     }
 }

--- a/BassClefStudio.AppModel.Console/BassClefStudio.AppModel.Console.csproj
+++ b/BassClefStudio.AppModel.Console/BassClefStudio.AppModel.Console.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
-    <Version>1.8.6</Version>
+    <Version>1.9.0</Version>
     <Authors>BassClefStudio</Authors>
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications in .NET Console applications.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>

--- a/BassClefStudio.AppModel.Console/Navigation/ConsoleNavigationService.cs
+++ b/BassClefStudio.AppModel.Console/Navigation/ConsoleNavigationService.cs
@@ -9,11 +9,10 @@ namespace BassClefStudio.AppModel.Navigation
     /// <summary>
     /// An <see cref="INavigationService"/> built on the <see cref="ConsoleView{T}"/> abstract class.
     /// </summary>
-    public class ConsoleNavigationService : INavigationService
+    public class ConsoleNavigationService : NavigationService<IConsoleView>, INavigationService
     {
-        internal string AppName { get; }
-        internal Version Version { get; }
-
+        private string AppName { get; }
+        private Version Version { get; }
         /// <summary>
         /// Creates a new <see cref="ConsoleNavigationService"/>.
         /// </summary>
@@ -25,7 +24,7 @@ namespace BassClefStudio.AppModel.Navigation
         }
 
         /// <inheritdoc/>
-        public void InitializeNavigation()
+        public override void InitializeNavigation()
         {
             Console.ForegroundColor = ConsoleColor.Yellow;
             Console.WriteLine($"{AppName} v{Version}");
@@ -33,18 +32,11 @@ namespace BassClefStudio.AppModel.Navigation
         }
 
         /// <inheritdoc/>
-        public void Navigate(IView view)
+        protected override void NavigateInternal(IConsoleView view)
         {
-            if (view is IConsoleView consoleView)
-            {
-                SynchronousTask syncTask = new SynchronousTask(
-                    () => consoleView.ShowView());
-                syncTask.RunTask();
-            }
-            else
-            {
-                throw new ArgumentException($"Console navigation usually expects that the resolved IViews be IConsoleViews. View type: {view?.GetType().Name}");
-            }
+            SynchronousTask syncTask = new SynchronousTask(
+                    () => view.ShowView());
+            syncTask.RunTask();
         }
     }
 }

--- a/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
+++ b/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>BassClefStudio.AppModel.Uwp</id>
-    <version>1.8.6</version>
+    <version>1.9.0</version>
     <title>BassClefStudio.AppModel.Uwp</title>
     <authors>BassClefStudio</authors>
     <owners>BassClefStudio</owners>
@@ -12,7 +12,7 @@
     <dependencies>
       <group targetFramework="uap10.0.17763">
         <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.2.10"/>
-        <dependency id="BassClefStudio.AppModel" version="1.8.6"/>
+        <dependency id="BassClefStudio.AppModel" version="1.9.0"/>
         <dependency id="Microsoft.Toolkit.Uwp.Notifications" version="7.0.1"/>
       </group>
     </dependencies>

--- a/BassClefStudio.AppModel.Uwp/Lifecycle/UwpApplication.cs
+++ b/BassClefStudio.AppModel.Uwp/Lifecycle/UwpApplication.cs
@@ -72,7 +72,10 @@ namespace BassClefStudio.AppModel.Lifecycle
 
         private void BackRequested(object sender, BackRequestedEventArgs e)
         {
-            CurrentApp.GoBack();
+            if (CurrentApp.CanGoBack)
+            {
+                CurrentApp.GoBack();
+            }
             e.Handled = true;
         }
 

--- a/BassClefStudio.AppModel.Wpf/BassClefStudio.AppModel.Wpf.csproj
+++ b/BassClefStudio.AppModel.Wpf/BassClefStudio.AppModel.Wpf.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Authors>BassClefStudio</Authors>
-    <Version>1.8.6</Version>
+    <Version>1.9.0</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications on .NET 5 with WPF.</Description>

--- a/BassClefStudio.AppModel.Wpf/Navigation/WpfNavigationService.cs
+++ b/BassClefStudio.AppModel.Wpf/Navigation/WpfNavigationService.cs
@@ -13,25 +13,33 @@ namespace BassClefStudio.AppModel.Navigation
     /// <summary>
     /// An <see cref="INavigationService"/> built on the WPF's <see cref="ContentControl"/> and <see cref="Window"/> classes.
     /// </summary>
-    public class WpfNavigationService : INavigationService
+    public class WpfNavigationService : NavigationService<UIElement>, INavigationService
     {
+        private ContentControl currentFrame;
         /// <summary>
         /// The current frame for navigation content.
         /// </summary>
-        public ContentControl CurrentFrame { get; set; }
+        public ContentControl CurrentFrame
+        {
+            get => currentFrame;
+            set
+            {
+                if (currentFrame != value)
+                {
+                    currentFrame = value;
+                    NavigationStack.Clear();
+                }
+            }
+        }
 
-        internal IDispatcherService DispatcherService { get; }
         /// <summary>
         /// Creates a new <see cref="WpfNavigationService"/>.
         /// </summary>
-        /// <param name="dispatcherService">The <see cref="IDispatcherService"/> for running UI code on the correct thread.</param>
-        public WpfNavigationService(IDispatcherService dispatcherService)
-        {
-            DispatcherService = dispatcherService;
-        }
+        public WpfNavigationService()
+        { }
 
         /// <inheritdoc/>
-        public void InitializeNavigation()
+        public override void InitializeNavigation()
         {
             var myWindow = new Window();
             Application.Current.MainWindow = myWindow;
@@ -40,20 +48,15 @@ namespace BassClefStudio.AppModel.Navigation
         }
 
         /// <inheritdoc/>
-        public void Navigate(IView view)
+        protected override void NavigateInternal(UIElement element)
         {
-            if (!(view is UIElement))
-            {
-                Debug.Write($"WPF Navigation usually expects that the resolved IViews be UIElements. View type: {view?.GetType().Name}");
-            }
-
-            if (view is Window window)
+            if (element is Window window)
             {
                 window.Show();
             }
             else
             {
-                CurrentFrame.Content = view;
+                CurrentFrame.Content = element;
             }
         }
     }

--- a/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
+++ b/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
@@ -7,7 +7,7 @@
     <Description>A .NET Standard, platform-agnostic library for creating cross-platform view-models and applications for various .NET platforms.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
-    <Version>1.8.8</Version>
+    <Version>1.9.0</Version>
     <AssemblyName>BassClefStudio.AppModel</AssemblyName>
   </PropertyGroup>
 

--- a/BassClefStudio.AppModel/Helpers/ShellViewModel.cs
+++ b/BassClefStudio.AppModel/Helpers/ShellViewModel.cs
@@ -93,17 +93,17 @@ namespace BassClefStudio.AppModel.Helpers
             BackStream = new SourceStream<bool>();
             BackStream.BindResult(b =>
             {
-                if (b && MyApp.CanGoBack())
+                if (b && MyApp.CanGoBack)
                 {
                     MyApp.GoBack();
-                    BackEnabled = MyApp.CanGoBack();
+                    BackEnabled = MyApp.CanGoBack;
                 }
             });
             //// Starting an empty SourceStream doesn't actually *do* anything, but still...
             _ = NavigateStream.StartAsync();
             _ = BackStream.StartAsync();
 
-            BackEnabled = MyApp.CanGoBack();
+            BackEnabled = MyApp.CanGoBack;
         }
 
         /// <inheritdoc/>
@@ -113,7 +113,7 @@ namespace BassClefStudio.AppModel.Helpers
         {
             var viewModelType = e.NavigatedViewModel.GetType();
             SetSelected(NavigationItems.FirstOrDefault(i => i.ViewModelType == viewModelType));
-            BackEnabled = MyApp.CanGoBack();
+            BackEnabled = MyApp.CanGoBack;
         }
 
         /// <summary>

--- a/BassClefStudio.AppModel/Helpers/ShellViewModel.cs
+++ b/BassClefStudio.AppModel/Helpers/ShellViewModel.cs
@@ -129,7 +129,7 @@ namespace BassClefStudio.AppModel.Helpers
         /// </summary>
         public void Navigate()
         {
-            MyApp.NavigateReflection(SelectedItem.ViewModelType);
+            MyApp.NavigateReflection(SelectedItem.ViewModelType, SelectedItem.Parameter);
         }
     }
 
@@ -154,16 +154,23 @@ namespace BassClefStudio.AppModel.Helpers
         public char Icon { get; }
 
         /// <summary>
+        /// An optional <see cref="object"/> parameter to pass to the navigation service when navigating to the specified page.
+        /// </summary>
+        public object Parameter { get; }
+
+        /// <summary>
         /// Creates a new <see cref="NavigationItem"/>.
         /// </summary>
         /// <param name="name">The display name of the <see cref="NavigationItem"/>.</param>
         /// <param name="viewModelType">The type of the view-model (<see cref="IViewModel"/>) that this <see cref="NavigationItem"/> refers to.</param>
         /// <param name="icon">A <see cref="char"/> that represents the icon of this <see cref="NavigationItem"/>.</param>
-        public NavigationItem(string name, Type viewModelType, char icon)
+        /// <param name="param">An optional <see cref="object"/> parameter to pass to the navigation service when navigating to the specified page.</param>
+        public NavigationItem(string name, Type viewModelType, char icon, object param = null)
         {
             Name = name;
             ViewModelType = viewModelType;
             Icon = icon;
+            Parameter = param;
         }
     }
 }

--- a/BassClefStudio.AppModel/Helpers/ShellViewModel.cs
+++ b/BassClefStudio.AppModel/Helpers/ShellViewModel.cs
@@ -93,17 +93,17 @@ namespace BassClefStudio.AppModel.Helpers
             BackStream = new SourceStream<bool>();
             BackStream.BindResult(b =>
             {
-                if (b && MyApp.CanGoBack)
+                if (b && MyApp.CanGoBack())
                 {
                     MyApp.GoBack();
-                    BackEnabled = MyApp.CanGoBack;
+                    BackEnabled = MyApp.CanGoBack();
                 }
             });
             //// Starting an empty SourceStream doesn't actually *do* anything, but still...
             _ = NavigateStream.StartAsync();
             _ = BackStream.StartAsync();
 
-            BackEnabled = MyApp.CanGoBack;
+            BackEnabled = MyApp.CanGoBack();
         }
 
         /// <inheritdoc/>
@@ -113,7 +113,7 @@ namespace BassClefStudio.AppModel.Helpers
         {
             var viewModelType = e.NavigatedViewModel.GetType();
             SetSelected(NavigationItems.FirstOrDefault(i => i.ViewModelType == viewModelType));
-            BackEnabled = MyApp.CanGoBack;
+            BackEnabled = MyApp.CanGoBack();
         }
 
         /// <summary>

--- a/BassClefStudio.AppModel/Lifecycle/App.cs
+++ b/BassClefStudio.AppModel/Lifecycle/App.cs
@@ -302,7 +302,6 @@ namespace BassClefStudio.AppModel.Lifecycle
             initViewModelTask.RunTask();
             view.Initialize();
             var args = new NavigatedEventArgs(view, viewModel, parameter);
-            NavigationStack.Push(args);
             Navigated?.Invoke(this, args);
         }
 
@@ -318,35 +317,22 @@ namespace BassClefStudio.AppModel.Lifecycle
             }
         }
 
-        private Stack<NavigatedEventArgs> NavigationStack { get; } = new Stack<NavigatedEventArgs>();
-
         /// <summary>
         /// A <see cref="bool"/> indicating whether the <see cref="App"/> can initiate back navigation - trigger this by calling the <see cref="GoBack"/> navigation method.
         /// </summary>
-        public bool CanGoBack => NavigationStack.Count > 1;
+        public bool CanGoBack()
+        {
+            var navService = Services.Resolve<INavigationService>();
+            return navService.CanGoBack;
+        }
 
         /// <summary>
         /// Initiates a request to return to the last saved state of the application (i.e. a back button was pressed or gesture detected).
         /// </summary>
-        /// <returns>A <see cref="bool"/> indicating whether the <see cref="App"/> could, and did, initiate navigation to a previous page.</returns>
-        public bool GoBack()
+        public void GoBack()
         {
-            if (NavigationStack.Count > 1)
-            {
-                //// Pops the current state from the navigation stack.
-                NavigationStack.Pop();
-                //// Peeks at the previously-saved state.
-                var args = NavigationStack.Peek();
-                //// TODO: Potentially create a new instance of the view-model, rather than navigating to the currently existing one. Note this means IViewModel.InitializeAsync() is called twice.
-                var navService = Services.Resolve<INavigationService>();
-                //// The view-model, etc. for this view is already set-up!
-                navService.Navigate(args.NavigatedView);
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            var navService = Services.Resolve<INavigationService>();
+            navService.GoBack();
         }
 
         #endregion

--- a/BassClefStudio.AppModel/Lifecycle/App.cs
+++ b/BassClefStudio.AppModel/Lifecycle/App.cs
@@ -212,8 +212,8 @@ namespace BassClefStudio.AppModel.Lifecycle
 
         private void ActivateForeground(IActivatedEventArgs args)
         {
-            var navService = Services.Resolve<INavigationService>();
-            navService.InitializeNavigation();
+            NavigationService = Services.Resolve<INavigationService>();
+            NavigationService.InitializeNavigation();
 
             var shellHandler = Services.ResolveOptional<IShellHandler>();
             if (shellHandler != null)
@@ -238,6 +238,8 @@ namespace BassClefStudio.AppModel.Lifecycle
         #endregion
         #region Navigation
 
+        private INavigationService NavigationService { get; set; }
+
         /// <summary>
         /// Resolves the given <see cref="IViewModel"/>'s view dependencies for the platform and navigates to a new view.
         /// </summary>
@@ -258,8 +260,7 @@ namespace BassClefStudio.AppModel.Lifecycle
         public void Navigate<T>(T viewModel, object parameter = null) where T : IViewModel
         {
             var view = Services.Resolve<IView<T>>();
-            var navService = Services.Resolve<INavigationService>();
-            navService.Navigate(view);
+            NavigationService.Navigate(view);
             view.ViewModel = viewModel;
             NavigatedInitialize(viewModel, view, parameter);
         }
@@ -274,8 +275,7 @@ namespace BassClefStudio.AppModel.Lifecycle
             var viewType = typeof(IView<>).MakeGenericType(viewModelType);
             var viewModel = (IViewModel)Services.Resolve(viewModelType);
             var view = (IView)Services.Resolve(viewType);
-            var navService = Services.Resolve<INavigationService>();
-            navService.Navigate(view);
+            NavigationService.Navigate(view);
             viewType.GetProperty("ViewModel").SetValue(view, viewModel);
             NavigatedInitialize(viewModel, view, parameter);
         }
@@ -289,9 +289,8 @@ namespace BassClefStudio.AppModel.Lifecycle
         {
             var viewType = typeof(IView<>).MakeGenericType(viewModel.GetType());
             var view = (IView)Services.Resolve(viewType);
-            var navService = Services.Resolve<INavigationService>();
             viewType.GetProperty("ViewModel").SetValue(view, viewModel);
-            navService.Navigate(view);
+            NavigationService.Navigate(view);
             NavigatedInitialize(viewModel, view, parameter);
         }
 
@@ -320,20 +319,12 @@ namespace BassClefStudio.AppModel.Lifecycle
         /// <summary>
         /// A <see cref="bool"/> indicating whether the <see cref="App"/> can initiate back navigation - trigger this by calling the <see cref="GoBack"/> navigation method.
         /// </summary>
-        public bool CanGoBack()
-        {
-            var navService = Services.Resolve<INavigationService>();
-            return navService.CanGoBack;
-        }
+        public bool CanGoBack => NavigationService.CanGoBack;
 
         /// <summary>
         /// Initiates a request to return to the last saved state of the application (i.e. a back button was pressed or gesture detected).
         /// </summary>
-        public void GoBack()
-        {
-            var navService = Services.Resolve<INavigationService>();
-            navService.GoBack();
-        }
+        public void GoBack() => NavigationService.GoBack();
 
         #endregion
         #endregion


### PR DESCRIPTION
Complete overhaul of back navigation, moving it to the `INavigationService` and then implementing a base `NavigationService` with a back `Stack<T>` of navigated pages. This should alleviate the platform-specific issues with back navigation, such as UWP and WPF needing to clear the stack when the `ContentControl` in which content was displayed changes.