### PR TITLE
v1.11.2 - UWP and WPF value converter helpers.

### DIFF
--- a/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.csproj
+++ b/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.csproj
@@ -123,7 +123,9 @@
   <ItemGroup>
     <Compile Include="Background\UwpBackgroundService.cs" />
     <Compile Include="Background\UwpDeferral.cs" />
+    <Compile Include="Helpers\CompositeConverter.cs" />
     <Compile Include="Helpers\TypeTemplateSelector.cs" />
+    <Compile Include="Helpers\VisibilityConverter.cs" />
     <Compile Include="Lifecycle\UwpApplication.cs" />
     <Compile Include="Navigation\UwpNavigationService.cs" />
     <Compile Include="Notifications\UwpNotificationService.cs" />

--- a/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
+++ b/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>BassClefStudio.AppModel.Uwp</id>
-    <version>1.11.1</version>
+    <version>1.11.2</version>
     <title>BassClefStudio.AppModel.Uwp</title>
     <authors>BassClefStudio</authors>
     <owners>BassClefStudio</owners>

--- a/BassClefStudio.AppModel.Uwp/Helpers/CompositeConverter.cs
+++ b/BassClefStudio.AppModel.Uwp/Helpers/CompositeConverter.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Markup;
+
+namespace BassClefStudio.AppModel.Helpers
+{
+    /// <summary>
+    /// An <see cref="IValueConverter"/> that allows for the composition of multiple child <see cref="IValueConverter"/>s into one single <see cref="IValueConverter"/> that can be used in binding.
+    /// </summary>
+    [ContentProperty(Name = nameof(Converters))]
+    public class CompositeConverter : IValueConverter
+    {
+        /// <summary>
+        /// A collection, in order, of the <see cref="IValueConverter"/> components of this <see cref="CompositeConverter"/>.
+        /// </summary>
+        public List<IValueConverter> Converters { get; set; }
+
+        /// <summary>
+        /// Creates a new <see cref="CompositeConverter"/>.
+        /// </summary>
+        public CompositeConverter()
+        {
+            Converters = new List<IValueConverter>();
+        }
+
+        /// <inheritdoc/>
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            var currrent = value;
+            foreach (var con in Converters)
+            {
+                currrent = con.Convert(currrent, targetType, parameter, language);
+            }
+            return currrent;
+        }
+
+        /// <inheritdoc/>
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            var currrent = value;
+            foreach (var con in Converters.Reverse<IValueConverter>())
+            {
+                currrent = con.ConvertBack(currrent, targetType, parameter, language);
+            }
+            return currrent;
+        }
+    }
+}

--- a/BassClefStudio.AppModel.Uwp/Helpers/VisibilityConverter.cs
+++ b/BassClefStudio.AppModel.Uwp/Helpers/VisibilityConverter.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Data;
+
+namespace BassClefStudio.AppModel.Helpers
+{
+    /// <summary>
+    /// An <see cref="IValueConverter"/> for converting between <see cref="Visibility"/> and <see cref="bool"/> values.
+    /// </summary>
+    public class VisibilityConverter : IValueConverter
+    {
+        /// <summary>
+        /// A <see cref="bool"/> indicating whether the input <see cref="bool"/> values should be inverted before converting them into true/<see cref="Visibility.Visible"/> and false/<see cref="Visibility.Collapsed"/>.
+        /// </summary>
+        public bool IsInverted { get; set; }
+
+        /// <inheritdoc/>
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            if(value is bool b)
+            {
+                return b == !IsInverted ? Visibility.Visible : Visibility.Collapsed;
+            }
+            else
+            {
+                return Visibility.Collapsed;
+            }
+        }
+
+        /// <inheritdoc/>
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            if(value is Visibility v)
+            {
+                return v == Visibility.Visible ? !IsInverted : IsInverted;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/BassClefStudio.AppModel.Wpf/BassClefStudio.AppModel.Wpf.csproj
+++ b/BassClefStudio.AppModel.Wpf/BassClefStudio.AppModel.Wpf.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Authors>BassClefStudio</Authors>
-    <Version>1.11.1</Version>
+    <Version>1.11.2</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications on .NET 5 with WPF.</Description>

--- a/BassClefStudio.AppModel.Wpf/Helpers/CompositeConverter.cs
+++ b/BassClefStudio.AppModel.Wpf/Helpers/CompositeConverter.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+using System.Windows.Markup;
+
+namespace BassClefStudio.AppModel.Helpers
+{
+    /// <summary>
+    /// An <see cref="IValueConverter"/> that allows for the composition of multiple child <see cref="IValueConverter"/>s into one single <see cref="IValueConverter"/> that can be used in binding.
+    /// </summary>
+    [ContentProperty(nameof(Converters))]
+    public class CompositeConverter : IValueConverter
+    {
+        /// <summary>
+        /// A collection, in order, of the <see cref="IValueConverter"/> components of this <see cref="CompositeConverter"/>.
+        /// </summary>
+        public List<IValueConverter> Converters { get; set; }
+
+        /// <summary>
+        /// Creates a new <see cref="CompositeConverter"/>.
+        /// </summary>
+        public CompositeConverter()
+        {
+            Converters = new List<IValueConverter>();
+        }
+
+        /// <inheritdoc/>
+        public object Convert(object value, Type targetType, object parameter, CultureInfo cultureInfo)
+        {
+            var currrent = value;
+            foreach (var con in Converters)
+            {
+                currrent = con.Convert(currrent, targetType, parameter, cultureInfo);
+            }
+            return currrent;
+        }
+
+        /// <inheritdoc/>
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo cultureInfo)
+        {
+            var currrent = value;
+            foreach (var con in Converters.Reverse<IValueConverter>())
+            {
+                currrent = con.ConvertBack(currrent, targetType, parameter, cultureInfo);
+            }
+            return currrent;
+        }
+    }
+}

--- a/BassClefStudio.AppModel.Wpf/Helpers/VisibilityConverter.cs
+++ b/BassClefStudio.AppModel.Wpf/Helpers/VisibilityConverter.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Data;
+
+namespace BassClefStudio.AppModel.Helpers
+{
+    /// <summary>
+    /// An <see cref="IValueConverter"/> for converting between <see cref="Visibility"/> and <see cref="bool"/> values.
+    /// </summary>
+    public class VisibilityConverter : IValueConverter
+    {
+        /// <summary>
+        /// A <see cref="bool"/> indicating whether the input <see cref="bool"/> values should be inverted before converting them into true/<see cref="Visibility.Visible"/> and false/<see cref="Visibility.Collapsed"/>.
+        /// </summary>
+        public bool IsInverted { get; set; }
+
+        /// <inheritdoc/>
+        public object Convert(object value, Type targetType, object parameter, CultureInfo cultureInfo)
+        {
+            if(value is bool b)
+            {
+                return b == !IsInverted ? Visibility.Visible : Visibility.Collapsed;
+            }
+            else
+            {
+                return Visibility.Collapsed;
+            }
+        }
+
+        /// <inheritdoc/>
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo cultureInfo)
+        {
+            if(value is Visibility v)
+            {
+                return v == Visibility.Visible ? !IsInverted : IsInverted;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Presenting the `VisibilityConverter` (`bool` to `Visibility`) and `CompositeConverter` (supports chaining `IValueConverter`s together) on both the `.Uwp` and `.Wpf` projects.

Closes #82.