### PR TITLE
Added ILauncher interface (UWP-only support for now)

### DIFF
--- a/BassClefStudio.AppModel.Base/BassClefStudio.AppModel.Base.csproj
+++ b/BassClefStudio.AppModel.Base/BassClefStudio.AppModel.Base.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>BassClefStudio</Authors>
-    <Version>1.12.0</Version>
+    <Version>1.12.1</Version>
     <Description>Services and classes for the BassClefStudio.AppModel library that provide basic features for cross-platform MVVM applications running on .NET Standard.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>

--- a/BassClefStudio.AppModel.Blazor/BassClefStudio.AppModel.Blazor.csproj
+++ b/BassClefStudio.AppModel.Blazor/BassClefStudio.AppModel.Blazor.csproj
@@ -5,7 +5,7 @@
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications on .NET 5 with Blazor.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
-    <Version>1.12.0</Version>
+    <Version>1.12.1</Version>
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/BassClefStudio.AppModel.Console/BassClefStudio.AppModel.Console.csproj
+++ b/BassClefStudio.AppModel.Console/BassClefStudio.AppModel.Console.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
-    <Version>1.12.0</Version>
+    <Version>1.12.1</Version>
     <Authors>BassClefStudio</Authors>
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications in .NET Console applications.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>

--- a/BassClefStudio.AppModel.Console/Storage/ConsoleStorageService.cs
+++ b/BassClefStudio.AppModel.Console/Storage/ConsoleStorageService.cs
@@ -16,17 +16,26 @@ namespace BassClefStudio.AppModel.Storage
         /// <inheritdoc/>
         public IStorageFolder AppDataFolder { get; }
 
+        /// <inheritdoc/>
+        public IStorageFolder TempFolder { get; }
+
         /// <summary>
         /// Creates a new <see cref="ConsoleStorageService"/> from the current <see cref="App"/>
         /// </summary>
         /// <param name="packageInfo">The app's <see cref="IPackageInfo"/> provides information used to determine the location of the local folder.</param>
         public ConsoleStorageService(IPackageInfo packageInfo)
         {
+            var appDataPath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                packageInfo.ApplicationName);
+
+            var tempPath = Path.Combine(appDataPath, "temp");
+
             AppDataFolder = new BaseFolder(
-                new DirectoryInfo(
-                    Path.Combine(
-                        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                        packageInfo.ApplicationName)));
+                new DirectoryInfo(appDataPath));
+
+            TempFolder = new BaseFolder(
+                new DirectoryInfo(tempPath));
         }
 
         /// <inheritdoc/>

--- a/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.csproj
+++ b/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Helpers\TypeTemplateSelector.cs" />
     <Compile Include="Helpers\VisibilityConverter.cs" />
     <Compile Include="Lifecycle\UwpApplication.cs" />
+    <Compile Include="Lifecycle\UwpLauncher.cs" />
     <Compile Include="Navigation\UwpNavigationService.cs" />
     <Compile Include="Notifications\UwpNotificationService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
+++ b/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>BassClefStudio.AppModel.Uwp</id>
-    <version>1.12.0</version>
+    <version>1.12.1</version>
     <title>BassClefStudio.AppModel.Uwp</title>
     <authors>BassClefStudio</authors>
     <owners>BassClefStudio</owners>
@@ -12,7 +12,7 @@
     <dependencies>
       <group targetFramework="uap10.0.17763">
         <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.2.10"/>
-        <dependency id="BassClefStudio.AppModel" version="1.12.0"/>
+        <dependency id="BassClefStudio.AppModel" version="1.12.1"/>
         <dependency id="Microsoft.Toolkit.Uwp.Notifications" version="7.0.1"/>
       </group>
     </dependencies>

--- a/BassClefStudio.AppModel.Uwp/Lifecycle/UwpAppPlatform.cs
+++ b/BassClefStudio.AppModel.Uwp/Lifecycle/UwpAppPlatform.cs
@@ -30,6 +30,8 @@ namespace BassClefStudio.AppModel.Lifecycle
                 .AsImplementedInterfaces();
             builder.RegisterType<UwpNotificationService>()
                 .AsImplementedInterfaces();
+            builder.RegisterType<UwpLauncher>()
+                .AsImplementedInterfaces();
         }
     }
 }

--- a/BassClefStudio.AppModel.Uwp/Lifecycle/UwpLauncher.cs
+++ b/BassClefStudio.AppModel.Uwp/Lifecycle/UwpLauncher.cs
@@ -1,0 +1,82 @@
+﻿using BassClefStudio.AppModel.Storage;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.System;
+
+namespace BassClefStudio.AppModel.Lifecycle
+{
+    /// <summary>
+    /// A UWP wrapper around <see cref="Windows.System.Launcher"/> which implements the <see cref="ILauncher"/> methods and also provides for the opening of non-UWP resources.
+    /// </summary>
+    public class UwpLauncher : ILauncher
+    {
+        private IStorageService StorageService { get; }
+        /// <summary>
+        /// Creates a new <see cref="UwpLauncher"/> from the required services.
+        /// </summary>
+        public UwpLauncher(IStorageService storageService)
+        {
+            StorageService = storageService;
+        }
+
+        /// <inheritdoc/>
+        public async Task<bool> OpenFileAsync(IStorageFile file)
+        {
+            if (file is UwpFile uwpFile)
+            {
+                return await Launcher.LaunchFileAsync(uwpFile.File);
+            }
+            else
+            {
+                var newFile = await file.CopyToAsync(StorageService.TempFolder);
+                if (newFile is UwpFile uwpNewFile)
+                {
+                    return await Launcher.LaunchFileAsync(uwpNewFile.File);
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task<bool> ShowFileAsync(IStorageFile file)
+        {
+            if (file.HasPath)
+            {
+                return await Launcher.LaunchUriAsync(new Uri(file.GetPath()));
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task<bool> ShowFolderAsync(IStorageFolder folder)
+        {
+            if (folder is UwpFolder uwpFolder)
+            {
+                return await Launcher.LaunchFolderAsync(uwpFolder.Folder);
+            }
+            else if(folder.HasPath)
+            {
+                return await Launcher.LaunchUriAsync(new Uri(folder.GetPath()));
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task<bool> OpenLinkAsync(Uri link)
+        {
+            return await Launcher.LaunchUriAsync(link);
+        }
+    }
+}

--- a/BassClefStudio.AppModel.Uwp/Storage/UwpFile.cs
+++ b/BassClefStudio.AppModel.Uwp/Storage/UwpFile.cs
@@ -11,7 +11,7 @@ namespace BassClefStudio.AppModel.Storage
     /// </summary>
     public class UwpFile : IStorageFile
     {
-        private Windows.Storage.IStorageFile File { get; }
+        internal Windows.Storage.IStorageFile File { get; }
 
         public UwpFile(Windows.Storage.IStorageFile file)
         {

--- a/BassClefStudio.AppModel.Uwp/Storage/UwpFolder.cs
+++ b/BassClefStudio.AppModel.Uwp/Storage/UwpFolder.cs
@@ -11,7 +11,7 @@ namespace BassClefStudio.AppModel.Storage
     /// </summary>
     public class UwpFolder : IStorageFolder
     {
-        public Windows.Storage.IStorageFolder Folder { get; }
+        internal Windows.Storage.IStorageFolder Folder { get; }
 
         public UwpFolder(Windows.Storage.IStorageFolder folder)
         {

--- a/BassClefStudio.AppModel.Uwp/Storage/UwpStorageService.cs
+++ b/BassClefStudio.AppModel.Uwp/Storage/UwpStorageService.cs
@@ -17,6 +17,9 @@ namespace BassClefStudio.AppModel.Storage
         /// <inheritdoc/>
         public IStorageFolder AppDataFolder { get; } = new UwpFolder(ApplicationData.Current.LocalFolder);
 
+        /// <inheritdoc/>
+        public IStorageFolder TempFolder { get; } = new UwpFolder(ApplicationData.Current.TemporaryFolder);
+
         private IEnumerable<IDispatcher> Dispatchers { get; }
         public UwpStorageService(IEnumerable<IDispatcher> dispatchers)
         {

--- a/BassClefStudio.AppModel.Wpf/BassClefStudio.AppModel.Wpf.csproj
+++ b/BassClefStudio.AppModel.Wpf/BassClefStudio.AppModel.Wpf.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Authors>BassClefStudio</Authors>
-    <Version>1.12.0</Version>
+    <Version>1.12.1</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications on .NET 5 with WPF.</Description>

--- a/BassClefStudio.AppModel.Wpf/Storage/WpfStorageService.cs
+++ b/BassClefStudio.AppModel.Wpf/Storage/WpfStorageService.cs
@@ -18,17 +18,26 @@ namespace BassClefStudio.AppModel.Storage
         /// <inheritdoc/>
         public IStorageFolder AppDataFolder { get; }
 
+        /// <inheritdoc/>
+        public IStorageFolder TempFolder { get; }
+
         /// <summary>
         /// Creates a new <see cref="WpfStorageService"/> from the current <see cref="Lifecycle.App"/>
         /// </summary>
         /// <param name="packageInfo">The app's <see cref="IPackageInfo"/> provides information used to determine the location of the local folder.</param>
         public WpfStorageService(IPackageInfo packageInfo)
         {
+            var appDataPath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                packageInfo.ApplicationName);
+
+            var tempPath = Path.Combine(appDataPath, "temp");
+
             AppDataFolder = new BaseFolder(
-                new System.IO.DirectoryInfo(
-                    Path.Combine(
-                        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                        packageInfo.ApplicationName)));
+                new DirectoryInfo(appDataPath));
+
+            TempFolder = new BaseFolder(
+                new DirectoryInfo(tempPath));
         }
 
         /// <inheritdoc/>

--- a/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
+++ b/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
@@ -7,7 +7,7 @@
     <Description>A .NET Standard, platform-agnostic library for creating cross-platform view-models and applications for various .NET platforms.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
-    <Version>1.12.0</Version>
+    <Version>1.12.1</Version>
     <AssemblyName>BassClefStudio.AppModel</AssemblyName>
   </PropertyGroup>
 

--- a/BassClefStudio.AppModel/Lifecycle/ILauncher.cs
+++ b/BassClefStudio.AppModel/Lifecycle/ILauncher.cs
@@ -1,0 +1,42 @@
+﻿using BassClefStudio.AppModel.Storage;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BassClefStudio.AppModel.Lifecycle
+{
+    /// <summary>
+    /// Represents the system's launcher interface for showing the user links, files, and other content in the default viewer for that platform.
+    /// </summary>
+    public interface ILauncher
+    {
+        /// <summary>
+        /// Opens the specified <see cref="IStorageFile"/> in whatever app is designed to handle this type of file.
+        /// </summary>
+        /// <param name="file">The <see cref="IStorageFile"/> file to launch.</param>
+        /// <returns>A <see cref="bool"/> indicating whether the operation succeeded.</returns>
+        Task<bool> OpenFileAsync(IStorageFile file);
+
+        /// <summary>
+        /// Shows the specified <see cref="IStorageFile"/> in the default file explorer, if available.
+        /// </summary>
+        /// <param name="file">The <see cref="IStorageFile"/> file to launch.</param>
+        /// <returns>A <see cref="bool"/> indicating whether the operation succeeded.</returns>
+        Task<bool> ShowFileAsync(IStorageFile file);
+
+        /// <summary>
+        /// Opens the specified <see cref="IStorageFolder"/> location in the default file explorer, if available.
+        /// </summary>
+        /// <param name="folder">The <see cref="IStorageFolder"/> folder to launch.</param>
+        /// <returns>A <see cref="bool"/> indicating whether the operation succeeded.</returns>
+        Task<bool> ShowFolderAsync(IStorageFolder folder);
+
+        /// <summary>
+        /// Attempts to open the given <see cref="Uri"/> either in the web browser or (in the case of a deep link) the app registered to handle the given link type.
+        /// </summary>
+        /// <param name="link">The <see cref="Uri"/> for the system to handle.</param>
+        /// <returns>A <see cref="bool"/> indicating whether the operation succeeded.</returns>
+        Task<bool> OpenLinkAsync(Uri link);
+    }
+}

--- a/BassClefStudio.AppModel/Storage/IStorageService.cs
+++ b/BassClefStudio.AppModel/Storage/IStorageService.cs
@@ -16,6 +16,11 @@ namespace BassClefStudio.AppModel.Storage
         IStorageFolder AppDataFolder { get; }
 
         /// <summary>
+        /// A reference to the <see cref="IStorageFolder"/> where an app can store temporary files/cache in the platform-specific file store. This folder may be periodically cleaned by the system.
+        /// </summary>
+        IStorageFolder TempFolder { get; }
+
+        /// <summary>
         /// Prompts the user to open a file from their local filesystem, and returns an <see cref="IStorageFile"/> reference to that file.
         /// </summary>
         /// <param name="settings">A <see cref="StorageDialogSettings"/> describing the appearance and filters of the storage dialog.</param>


### PR DESCRIPTION
The `ILauncher` and `UwpLauncher` are joined by a new `TempFolder` property to all `IStorageService`s (for storage of cache/temporary files in the app data store).

This partially addresses #86, though more work is needed for full support. 