### PR TITLE
Added ObservableControl classes to both the .Uwp and .Wpf heads.

### DIFF
--- a/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.csproj
+++ b/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Background\UwpBackgroundService.cs" />
     <Compile Include="Background\UwpDeferral.cs" />
     <Compile Include="Helpers\CompositeConverter.cs" />
+    <Compile Include="Helpers\ObservableControl.cs" />
     <Compile Include="Helpers\TypeTemplateSelector.cs" />
     <Compile Include="Helpers\VisibilityConverter.cs" />
     <Compile Include="Lifecycle\UwpApplication.cs" />

--- a/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
+++ b/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>BassClefStudio.AppModel.Uwp</id>
-    <version>1.12.2</version>
+    <version>1.12.3</version>
     <title>BassClefStudio.AppModel.Uwp</title>
     <authors>BassClefStudio</authors>
     <owners>BassClefStudio</owners>

--- a/BassClefStudio.AppModel.Uwp/Helpers/ObservableControl.cs
+++ b/BassClefStudio.AppModel.Uwp/Helpers/ObservableControl.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
+using BassClefStudio.NET.Core;
+
+namespace BassClefStudio.AppModel.Helpers
+{
+    /// <summary>
+    /// Extends the <see cref="Observable"/> class' property change notification framework to a <see cref="UserControl"/>.
+    /// </summary>
+    public class ObservableControl : UserControl, INotifyPropertyChanged
+    {
+        /// <summary>
+        /// An event which is fired whenever a related property in an inheriting type is set.
+        /// </summary>
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>
+        /// Sets the value of a field to a specific value and calls the <see cref="PropertyChanged"/> event.
+        /// </summary>
+        /// <typeparam name="T">The type of the value being set.</typeparam>
+        /// <param name="storage">The field to store the value.</param>
+        /// <param name="value">The value to store.</param>
+        /// <param name="propertyName">(Filled automatically) the name of the property being set.</param>
+        protected void Set<T>(ref T storage, T value, [CallerMemberName] string propertyName = null)
+        {
+            if (Equals(storage, value))
+            {
+                return;
+            }
+
+            storage = value;
+            OnPropertyChanged(propertyName);
+        }
+
+        /// <inheritdoc/>
+        protected void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/BassClefStudio.AppModel.Wpf/BassClefStudio.AppModel.Wpf.csproj
+++ b/BassClefStudio.AppModel.Wpf/BassClefStudio.AppModel.Wpf.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Authors>BassClefStudio</Authors>
-    <Version>1.12.2</Version>
+    <Version>1.12.3</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications on .NET 5 with WPF.</Description>

--- a/BassClefStudio.AppModel.Wpf/Helpers/ObservableControl.cs
+++ b/BassClefStudio.AppModel.Wpf/Helpers/ObservableControl.cs
@@ -1,0 +1,44 @@
+﻿using BassClefStudio.NET.Core;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+
+namespace BassClefStudio.AppModel.Helpers
+{
+    /// <summary>
+    /// Extends the <see cref="Observable"/> class' property change notification framework to a <see cref="UserControl"/>.
+    /// </summary>
+    public class ObservableControl : UserControl, INotifyPropertyChanged
+    {
+        /// <summary>
+        /// An event which is fired whenever a related property in an inheriting type is set.
+        /// </summary>
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        /// <summary>
+        /// Sets the value of a field to a specific value and calls the <see cref="PropertyChanged"/> event.
+        /// </summary>
+        /// <typeparam name="T">The type of the value being set.</typeparam>
+        /// <param name="storage">The field to store the value.</param>
+        /// <param name="value">The value to store.</param>
+        /// <param name="propertyName">(Filled automatically) the name of the property being set.</param>
+        protected void Set<T>(ref T storage, T value, [CallerMemberName] string propertyName = null)
+        {
+            if (Equals(storage, value))
+            {
+                return;
+            }
+
+            storage = value;
+            OnPropertyChanged(propertyName);
+        }
+
+        /// <inheritdoc/>
+        protected void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}


### PR DESCRIPTION
This adds a new helper class - `ObservableControl` - which can be used as a `UserControl` with all of the methods of the `Observable` class (from [.NET-Libraries](https://github.com/bassclefstudio/.NET-Libraries)) available.

Closes #88.