### PR TITLE
Redesigned navigation framework

### DIFF
--- a/BassClefStudio.AppModel.Base/BassClefStudio.AppModel.Base.csproj
+++ b/BassClefStudio.AppModel.Base/BassClefStudio.AppModel.Base.csproj
@@ -5,10 +5,11 @@
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>BassClefStudio</Authors>
-    <Version>1.13.0</Version>
+    <Version>2.0.0-beta1</Version>
     <Description>Services and classes for the BassClefStudio.AppModel library that provide basic features for cross-platform MVVM applications running on .NET Standard.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BassClefStudio.AppModel.Blazor/BassClefStudio.AppModel.Blazor.csproj
+++ b/BassClefStudio.AppModel.Blazor/BassClefStudio.AppModel.Blazor.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.1.0" />
-    <PackageReference Include="Blazored.LocalStorage" Version="4.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.5" />
+    <PackageReference Include="Blazored.LocalStorage" Version="4.1.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BassClefStudio.AppModel.Base\BassClefStudio.AppModel.Base.csproj" />

--- a/BassClefStudio.AppModel.Blazor/BassClefStudio.AppModel.Blazor.csproj
+++ b/BassClefStudio.AppModel.Blazor/BassClefStudio.AppModel.Blazor.csproj
@@ -5,9 +5,11 @@
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications on .NET 5 with Blazor.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
-    <Version>1.13.0</Version>
+    <Version>2.0.0-beta1</Version>
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.1.0" />

--- a/BassClefStudio.AppModel.Blazor/Lifecycle/BlazorAppPlatform.cs
+++ b/BassClefStudio.AppModel.Blazor/Lifecycle/BlazorAppPlatform.cs
@@ -18,10 +18,10 @@ namespace BassClefStudio.AppModel.Lifecycle
         /// <inheritdoc/>
         public void ConfigureServices(ContainerBuilder builder)
         {
-            builder.RegisterType<BlazorNavigationService>()
+            builder.RegisterType<BlazorViewProvider>()
                 .SingleInstance()
                 .AsImplementedInterfaces();
-            builder.RegisterType<BlazorViewProvider>()
+            builder.RegisterType<BlazorViewInfo>()
                 .SingleInstance()
                 .AsImplementedInterfaces();
             //builder.RegisterType<BlazorBackgroundService>()

--- a/BassClefStudio.AppModel.Blazor/Navigation/BlazorViewProvider.cs
+++ b/BassClefStudio.AppModel.Blazor/Navigation/BlazorViewProvider.cs
@@ -31,11 +31,18 @@ namespace BassClefStudio.AppModel.Navigation
         { }
 
         /// <inheritdoc/>
-        protected override void SetViewInternal(BlazorView view)
+        protected override void SetViewInternal(BlazorView view, NavigationMode mode)
         {
-            Console.WriteLine($"Navigate {view.ViewPath}.");
-            ViewProvider.CurrentView = view;
-            NavigationManager.NavigateTo($"{NavigationManager.BaseUri}{view.ViewPath}");
+            if (mode.OverlayMode == NavigationOverlay.Page)
+            {
+                Console.WriteLine($"Navigate {view.ViewPath}.");
+                ViewProvider.CurrentView = view;
+                NavigationManager.NavigateTo($"{NavigationManager.BaseUri}{view.ViewPath}");
+            }
+            else
+            {
+                throw new ArgumentException($"Blazor apps currently do not have support for the given OverlayMode {mode.OverlayMode}.");
+            }
         }
     }
 }

--- a/BassClefStudio.AppModel.Blazor/Navigation/BlazorViewProvider.cs
+++ b/BassClefStudio.AppModel.Blazor/Navigation/BlazorViewProvider.cs
@@ -9,18 +9,18 @@ using System.Threading.Tasks;
 namespace BassClefStudio.AppModel.Navigation
 {
     /// <summary>
-    /// Represents a <see cref="BlazorNavigationService"/> that navigates to URLs in the Blazor SPA and provides the current view information for components to retrieve their <see cref="IViewModel"/>.
+    /// Represents a <see cref="BlazorViewProvider"/> that navigates to URLs in the Blazor SPA and provides the current view information for components to retrieve their <see cref="IViewModel"/>.
     /// </summary>
-    public class BlazorNavigationService : NavigationService<BlazorView>, INavigationService
+    public class BlazorViewProvider : ViewProvider<BlazorView>, IViewProvider
     {
-        private IBlazorViewProvider ViewProvider { get; }
+        private IBlazorViewInfo ViewProvider { get; }
         private NavigationManager NavigationManager { get; }
         /// <summary>
-        /// Creates a new <see cref="BlazorNavigationService"/> from the required Blazor dependencies.
+        /// Creates a new <see cref="BlazorViewProvider"/> from the required Blazor dependencies.
         /// </summary>
         /// <param name="navigationManager">The Blazor platform <see cref="Microsoft.AspNetCore.Components.NavigationManager"/>.</param>
-        /// <param name="viewProvider">The <see cref="IBlazorViewProvider"/> that the <see cref="BlazorNavigationService"/> can inform about navigation events.</param>
-        public BlazorNavigationService(NavigationManager navigationManager, IBlazorViewProvider viewProvider)
+        /// <param name="viewProvider">The <see cref="IBlazorViewInfo"/> that the <see cref="BlazorViewProvider"/> can inform about navigation events.</param>
+        public BlazorViewProvider(NavigationManager navigationManager, IBlazorViewInfo viewProvider)
         {
             NavigationManager = navigationManager;
             ViewProvider = viewProvider;
@@ -31,12 +31,11 @@ namespace BassClefStudio.AppModel.Navigation
         { }
 
         /// <inheritdoc/>
-        protected override bool NavigateInternal(BlazorView view)
+        protected override void SetViewInternal(BlazorView view)
         {
             Console.WriteLine($"Navigate {view.ViewPath}.");
             ViewProvider.CurrentView = view;
             NavigationManager.NavigateTo($"{NavigationManager.BaseUri}{view.ViewPath}");
-            return true;
         }
     }
 }

--- a/BassClefStudio.AppModel.Blazor/Navigation/BlazorViewProvider.cs
+++ b/BassClefStudio.AppModel.Blazor/Navigation/BlazorViewProvider.cs
@@ -27,7 +27,7 @@ namespace BassClefStudio.AppModel.Navigation
         }
 
         /// <inheritdoc/>
-        public override void InitializeNavigation()
+        public override void StartUI()
         { }
 
         /// <inheritdoc/>

--- a/BassClefStudio.AppModel.Blazor/Navigation/IBlazorViewInfo.cs
+++ b/BassClefStudio.AppModel.Blazor/Navigation/IBlazorViewInfo.cs
@@ -9,7 +9,7 @@ namespace BassClefStudio.AppModel.Navigation
     /// <summary>
     /// A service that provides information about the currently navigated <see cref="BlazorView"/>.
     /// </summary>
-    public interface IBlazorViewProvider
+    public interface IBlazorViewInfo
     {
         /// <summary>
         /// The current <see cref="BlazorView"/> view.
@@ -23,9 +23,9 @@ namespace BassClefStudio.AppModel.Navigation
     }
 
     /// <summary>
-    /// A default implementation of <see cref="IBlazorViewProvider"/>.
+    /// A default implementation of <see cref="IBlazorViewInfo"/>.
     /// </summary>
-    public class BlazorViewProvider : IBlazorViewProvider
+    public class BlazorViewInfo : IBlazorViewInfo
     {
         private BlazorView currentView;
         /// <inheritdoc/>

--- a/BassClefStudio.AppModel.Console/BassClefStudio.AppModel.Console.csproj
+++ b/BassClefStudio.AppModel.Console/BassClefStudio.AppModel.Console.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
-    <Version>1.13.0</Version>
+    <Version>2.0.0-beta1</Version>
     <Authors>BassClefStudio</Authors>
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications in .NET Console applications.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BassClefStudio.AppModel.Console/Lifecycle/ConsoleAppPlatform.cs
+++ b/BassClefStudio.AppModel.Console/Lifecycle/ConsoleAppPlatform.cs
@@ -17,7 +17,7 @@ namespace BassClefStudio.AppModel.Lifecycle
         /// <inheritdoc/>
         public void ConfigureServices(ContainerBuilder builder)
         {
-            builder.RegisterType<ConsoleNavigationService>()
+            builder.RegisterType<ConsoleViewProvider>()
                 .AsImplementedInterfaces()
                 .SingleInstance();
             //builder.RegisterType<ConsoleBackgroundService>()

--- a/BassClefStudio.AppModel.Console/Lifecycle/LifecycleManager.cs
+++ b/BassClefStudio.AppModel.Console/Lifecycle/LifecycleManager.cs
@@ -24,7 +24,7 @@ namespace BassClefStudio.AppModel.Lifecycle
         public bool Enabled { get; } = true;
 
         /// <inheritdoc/>
-        public bool Initialize(App app)
+        public bool Initialize()
         {
             CompletionSource = new TaskCompletionSource<bool>();
             ApplicationTask = CompletionSource.Task;
@@ -32,7 +32,7 @@ namespace BassClefStudio.AppModel.Lifecycle
         }
 
         /// <inheritdoc/>
-        public bool Suspend(App app)
+        public bool Suspend()
         {
             CompletionSource.SetResult(true);
             return true;

--- a/BassClefStudio.AppModel.Console/Navigation/ConsoleViewProvider.cs
+++ b/BassClefStudio.AppModel.Console/Navigation/ConsoleViewProvider.cs
@@ -24,7 +24,7 @@ namespace BassClefStudio.AppModel.Navigation
         }
 
         /// <inheritdoc/>
-        public override void InitializeNavigation()
+        public override void StartUI()
         {
             Console.ForegroundColor = ConsoleColor.Yellow;
             Console.WriteLine($"{AppName} v{Version}");

--- a/BassClefStudio.AppModel.Console/Navigation/ConsoleViewProvider.cs
+++ b/BassClefStudio.AppModel.Console/Navigation/ConsoleViewProvider.cs
@@ -7,17 +7,17 @@ using System.Text;
 namespace BassClefStudio.AppModel.Navigation
 {
     /// <summary>
-    /// An <see cref="INavigationService"/> built on the <see cref="ConsoleView{T}"/> abstract class.
+    /// An <see cref="IViewProvider"/> built on the <see cref="ConsoleView{T}"/> abstract class.
     /// </summary>
-    public class ConsoleNavigationService : NavigationService<IConsoleView>, INavigationService
+    public class ConsoleViewProvider : ViewProvider<IConsoleView>, IViewProvider
     {
         private string AppName { get; }
         private Version Version { get; }
         /// <summary>
-        /// Creates a new <see cref="ConsoleNavigationService"/>.
+        /// Creates a new <see cref="ConsoleViewProvider"/>.
         /// </summary>
-        /// <param name="packageInfo">The <see cref="IPackageInfo"/> this <see cref="ConsoleNavigationService"/> uses to get <see cref="AppName"/> and <see cref="Version"/> info.</param>
-        public ConsoleNavigationService(IPackageInfo packageInfo)
+        /// <param name="packageInfo">The <see cref="IPackageInfo"/> this <see cref="ConsoleViewProvider"/> uses to get <see cref="AppName"/> and <see cref="Version"/> info.</param>
+        public ConsoleViewProvider(IPackageInfo packageInfo)
         {
             AppName = packageInfo.ApplicationName;
             Version = packageInfo.Version;
@@ -32,12 +32,11 @@ namespace BassClefStudio.AppModel.Navigation
         }
 
         /// <inheritdoc/>
-        protected override bool NavigateInternal(IConsoleView view)
+        protected override void SetViewInternal(IConsoleView view)
         {
             SynchronousTask syncTask = new SynchronousTask(
                     () => view.ShowView());
             syncTask.RunTask();
-            return true;
         }
     }
 }

--- a/BassClefStudio.AppModel.Console/Navigation/ConsoleViewProvider.cs
+++ b/BassClefStudio.AppModel.Console/Navigation/ConsoleViewProvider.cs
@@ -32,11 +32,18 @@ namespace BassClefStudio.AppModel.Navigation
         }
 
         /// <inheritdoc/>
-        protected override void SetViewInternal(IConsoleView view)
+        protected override void SetViewInternal(IConsoleView view, NavigationMode mode)
         {
-            SynchronousTask syncTask = new SynchronousTask(
-                    () => view.ShowView());
-            syncTask.RunTask();
+            if (mode.OverlayMode == NavigationOverlay.Page)
+            {
+                SynchronousTask syncTask = new SynchronousTask(
+                        () => view.ShowView());
+                syncTask.RunTask();
+            }
+            else
+            {
+                throw new ArgumentException($"Console apps currently do not have support for the given OverlayMode {mode.OverlayMode}.");
+            }
         }
     }
 }

--- a/BassClefStudio.AppModel.Tests/BassClefStudio.AppModel.Tests.csproj
+++ b/BassClefStudio.AppModel.Tests/BassClefStudio.AppModel.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.4" />
     <PackageReference Include="coverlet.collector" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/BassClefStudio.AppModel.Uwp/Background/UwpBackgroundService.cs
+++ b/BassClefStudio.AppModel.Uwp/Background/UwpBackgroundService.cs
@@ -32,7 +32,7 @@ namespace BassClefStudio.AppModel.Background
         { }
 
         /// <inheritdoc/>
-        public bool Initialize(App app)
+        public bool Initialize()
         {
             Registrations = new List<IBackgroundTaskRegistration>(BackgroundTaskRegistration.AllTasks.Values);
             return true;

--- a/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.csproj
+++ b/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.csproj
@@ -143,13 +143,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BassClefStudio.NET.Core">
-      <Version>2.0.0</Version>
+      <Version>2.0.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.12</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications">
-      <Version>7.0.1</Version>
+      <Version>7.0.2</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.csproj
+++ b/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.csproj
@@ -129,7 +129,7 @@
     <Compile Include="Helpers\VisibilityConverter.cs" />
     <Compile Include="Lifecycle\UwpApplication.cs" />
     <Compile Include="Lifecycle\UwpLauncher.cs" />
-    <Compile Include="Navigation\UwpNavigationService.cs" />
+    <Compile Include="Navigation\UwpViewProvider.cs" />
     <Compile Include="Notifications\UwpNotificationService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Lifecycle\UwpAppPlatform.cs" />

--- a/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
+++ b/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
@@ -2,18 +2,20 @@
 <package>
   <metadata>
     <id>BassClefStudio.AppModel.Uwp</id>
-    <version>1.13.0</version>
+    <version>2.0.0-beta1</version>
     <title>BassClefStudio.AppModel.Uwp</title>
     <authors>BassClefStudio</authors>
     <owners>BassClefStudio</owners>
-    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="expression">MIT</license>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <repository type="git" url="https://github.com/bassclefstudio/AppModel"/>
     <description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications on the UWP platform.</description>
     <dependencies>
       <group targetFramework="uap10.0.17763">
-        <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.2.10"/>
-        <dependency id="BassClefStudio.AppModel" version="1.13.0"/>
-        <dependency id="Microsoft.Toolkit.Uwp.Notifications" version="7.0.1"/>
+        <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.2.12"/>
+        <dependency id="BassClefStudio.AppModel" version="2.0.0-beta1"/>
+        <dependency id="BassClefStudio.NET.Core" version="2.0.4"/>
+        <dependency id="Microsoft.Toolkit.Uwp.Notifications" version="7.0.2"/>
       </group>
     </dependencies>
   </metadata>

--- a/BassClefStudio.AppModel.Uwp/Lifecycle/UwpAppPlatform.cs
+++ b/BassClefStudio.AppModel.Uwp/Lifecycle/UwpAppPlatform.cs
@@ -16,7 +16,7 @@ namespace BassClefStudio.AppModel.Lifecycle
         /// <inheritdoc/>
         public void ConfigureServices(ContainerBuilder builder)
         {
-            builder.RegisterType<UwpNavigationService>()
+            builder.RegisterType<UwpViewProvider>()
                 .SingleInstance()
                 .AsImplementedInterfaces();
             builder.RegisterType<UwpBackgroundService>()

--- a/BassClefStudio.AppModel.Uwp/Lifecycle/UwpApplication.cs
+++ b/BassClefStudio.AppModel.Uwp/Lifecycle/UwpApplication.cs
@@ -72,10 +72,7 @@ namespace BassClefStudio.AppModel.Lifecycle
 
         private void BackRequested(object sender, BackRequestedEventArgs e)
         {
-            if (CurrentApp.CanGoBack)
-            {
-                CurrentApp.GoBack();
-            }
+            CurrentApp.GoBack();
             e.Handled = true;
         }
 

--- a/BassClefStudio.AppModel.Uwp/Navigation/UwpViewProvider.cs
+++ b/BassClefStudio.AppModel.Uwp/Navigation/UwpViewProvider.cs
@@ -40,7 +40,7 @@ namespace BassClefStudio.AppModel.Navigation
         }
 
         /// <inheritdoc/>
-        public override void InitializeNavigation()
+        public override void StartUI()
         {
             Frame rootFrame = Window.Current.Content as Frame;
 

--- a/BassClefStudio.AppModel.Uwp/Navigation/UwpViewProvider.cs
+++ b/BassClefStudio.AppModel.Uwp/Navigation/UwpViewProvider.cs
@@ -10,9 +10,9 @@ using Windows.UI.Xaml.Controls;
 namespace BassClefStudio.AppModel.Navigation
 {
     /// <summary>
-    /// An <see cref="INavigationService"/> built on the UWP's <see cref="ContentControl"/> and <see cref="Window"/> classes.
+    /// An <see cref="IViewProvider"/> built on the UWP's <see cref="ContentControl"/> and <see cref="Window"/> classes.
     /// </summary>
-    public class UwpNavigationService : NavigationService<UIElement>, INavigationService
+    public class UwpViewProvider : ViewProvider<UIElement>, IViewProvider
     {
         private ContentControl currentFrame;
         /// <summary>
@@ -26,16 +26,15 @@ namespace BassClefStudio.AppModel.Navigation
                 if(currentFrame != value)
                 {
                     currentFrame = value;
-                    NavigationStack.Clear();
                 }
             }
         }
 
         private IEnumerable<IDispatcher> Dispatchers { get; }
         /// <summary>
-        /// Creates a new <see cref="UwpNavigationService"/>.
+        /// Creates a new <see cref="UwpViewProvider"/>.
         /// </summary>
-        public UwpNavigationService(IEnumerable<IDispatcher> dispatchers)
+        public UwpViewProvider(IEnumerable<IDispatcher> dispatchers)
         {
             Dispatchers = dispatchers;
         }
@@ -61,7 +60,7 @@ namespace BassClefStudio.AppModel.Navigation
         }
 
         /// <inheritdoc/>
-        protected override bool NavigateInternal(UIElement element)
+        protected override void SetViewInternal(UIElement element)
         {
             if (element is ContentDialog dialog)
             {
@@ -69,13 +68,10 @@ namespace BassClefStudio.AppModel.Navigation
                     () => Dispatchers.RunOnUIThreadAsync(
                         () => ShowDialogTask(dialog)));
                 showTask.RunTask();
-                //// Because dialogs must be closed first, before any other pages can be navigated to, they should be added to the back stack in UWP.
-                return true;
             }
             else
             {
                 CurrentFrame.Content = element;
-                return true;
             }
         }
 

--- a/BassClefStudio.AppModel.Uwp/Notifications/UwpNotificationService.cs
+++ b/BassClefStudio.AppModel.Uwp/Notifications/UwpNotificationService.cs
@@ -20,11 +20,6 @@ namespace BassClefStudio.AppModel.Notifications
             ToastNotifier = ToastNotificationManager.CreateToastNotifier();
         }
 
-        //public ScheduledToastNotification[] GetScheduledNotifications()
-        //{
-        //    return ToastNotifier.GetScheduledToastNotifications().ToArray();
-        //}
-
         /// <inheritdoc/>
         public async Task<string> ShowAlarmAsync(NotificationContent content, DateTimeOffset showTime)
         {

--- a/BassClefStudio.AppModel.Wpf/BassClefStudio.AppModel.Wpf.csproj
+++ b/BassClefStudio.AppModel.Wpf/BassClefStudio.AppModel.Wpf.csproj
@@ -3,12 +3,14 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Authors>BassClefStudio</Authors>
-    <Version>1.13.0</Version>
+    <Version>2.0.0-beta1</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications on .NET 5 with WPF.</Description>
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BassClefStudio.AppModel.Wpf/Lifecycle/WpfAppPlatform.cs
+++ b/BassClefStudio.AppModel.Wpf/Lifecycle/WpfAppPlatform.cs
@@ -19,7 +19,7 @@ namespace BassClefStudio.AppModel.Lifecycle
         /// <inheritdoc/>
         public void ConfigureServices(ContainerBuilder builder)
         {
-            builder.RegisterType<WpfNavigationService>()
+            builder.RegisterType<WpfViewProvider>()
                 .SingleInstance()
                 .AsImplementedInterfaces();
             //builder.RegisterType<WpfBackgroundService>()

--- a/BassClefStudio.AppModel.Wpf/Navigation/WpfViewProvider.cs
+++ b/BassClefStudio.AppModel.Wpf/Navigation/WpfViewProvider.cs
@@ -38,7 +38,7 @@ namespace BassClefStudio.AppModel.Navigation
         { }
 
         /// <inheritdoc/>
-        public override void InitializeNavigation()
+        public override void StartUI()
         {
             var myWindow = new Window();
             Application.Current.MainWindow = myWindow;

--- a/BassClefStudio.AppModel.Wpf/Navigation/WpfViewProvider.cs
+++ b/BassClefStudio.AppModel.Wpf/Navigation/WpfViewProvider.cs
@@ -11,9 +11,9 @@ using System.Windows.Controls;
 namespace BassClefStudio.AppModel.Navigation
 {
     /// <summary>
-    /// An <see cref="INavigationService"/> built on the WPF's <see cref="ContentControl"/> and <see cref="Window"/> classes.
+    /// An <see cref="IViewProvider"/> built on the WPF's <see cref="ContentControl"/> and <see cref="Window"/> classes.
     /// </summary>
-    public class WpfNavigationService : NavigationService<UIElement>, INavigationService
+    public class WpfViewProvider : ViewProvider<UIElement>, IViewProvider
     {
         private ContentControl currentFrame;
         /// <summary>
@@ -27,15 +27,14 @@ namespace BassClefStudio.AppModel.Navigation
                 if (currentFrame != value)
                 {
                     currentFrame = value;
-                    NavigationStack.Clear();
                 }
             }
         }
 
         /// <summary>
-        /// Creates a new <see cref="WpfNavigationService"/>.
+        /// Creates a new <see cref="WpfViewProvider"/>.
         /// </summary>
-        public WpfNavigationService()
+        public WpfViewProvider()
         { }
 
         /// <inheritdoc/>
@@ -48,17 +47,15 @@ namespace BassClefStudio.AppModel.Navigation
         }
 
         /// <inheritdoc/>
-        protected override bool NavigateInternal(UIElement element)
+        protected override void SetViewInternal(UIElement element)
         {
             if (element is Window window)
             {
                 window.Show();
-                return false;
             }
             else
             {
                 CurrentFrame.Content = element;
-                return true;
             }
         }
     }

--- a/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
+++ b/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
@@ -7,8 +7,10 @@
     <Description>A .NET Standard, platform-agnostic library for creating cross-platform view-models and applications for various .NET platforms.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
-    <Version>1.13.0</Version>
+    <Version>2.0.0-beta1</Version>
     <AssemblyName>BassClefStudio.AppModel</AssemblyName>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
+++ b/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.2.0" />
-    <PackageReference Include="BassClefStudio.NET.Core" Version="2.0.0" />
+    <PackageReference Include="BassClefStudio.NET.Core" Version="2.0.4" />
     <PackageReference Include="BassClefStudio.NET.Serialization" Version="2.3.0" />
     <PackageReference Include="BassClefStudio.NET.Sync" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/BassClefStudio.AppModel/Commands/StreamCommand.cs
+++ b/BassClefStudio.AppModel/Commands/StreamCommand.cs
@@ -25,7 +25,7 @@ namespace BassClefStudio.AppModel.Commands
         public CommandInfo Info { get; }
 
         /// <inheritdoc/>
-        public event EventHandler<StreamValue<T>> ValueEmitted;
+        public StreamBinding<T> ValueEmitted { get; }
 
         /// <summary>
         /// Creates a new <see cref="StreamCommand{T}"/>.
@@ -36,20 +36,15 @@ namespace BassClefStudio.AppModel.Commands
         {
             Info = info;
             TriggerStream = new SourceStream<T>();
+            ValueEmitted = TriggerStream.ValueEmitted;
             EnabledStream = enableStream ?? true.AsStream();
         }
 
         /// <inheritdoc/>
         public void Start()
         {
-            TriggerStream.ValueEmitted += CommandTriggered;
             TriggerStream.Start();
             EnabledStream.Start();
-        }
-
-        private void CommandTriggered(object sender, StreamValue<T> e)
-        {
-            ValueEmitted?.Invoke(this, e);
         }
 
         /// <inheritdoc/>

--- a/BassClefStudio.AppModel/Helpers/NavigationManager.cs
+++ b/BassClefStudio.AppModel/Helpers/NavigationManager.cs
@@ -1,0 +1,63 @@
+﻿using BassClefStudio.AppModel.Navigation;
+using BassClefStudio.NET.Core;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BassClefStudio.AppModel.Helpers
+{
+    /// <summary>
+    /// A default implementation of <see cref="INavigationService"/> that uses factory methods to create the necessary DI resources.
+    /// </summary>
+    public class NavigationManager : INavigationService
+    {
+        #region Initialization
+
+        /// <summary>
+        /// The injected <see cref="IViewProvider"/> for setting view content.
+        /// </summary>
+        public IViewProvider ViewProvider { get; set; }
+
+        /// <summary>
+        /// The injected <see cref="INavigationStack"/> history stack.
+        /// </summary>
+        public INavigationStack Stack { get; set; }
+
+        /// <summary>
+        /// The injected factory method for creating <see cref="IView"/>s of the given type.
+        /// </summary>
+        public Func<Type, IView> CreateView { get; set; }
+
+        /// <summary>
+        /// The injected factory method for creating <see cref="IViewModel"/>s of the given type.
+        /// </summary>
+        public Func<Type, IViewModel> CreateViewModel { get; set; }
+
+        #endregion
+        #region Methods
+
+        /// <inheritdoc/>
+        public void Initialize()
+        {
+            ViewProvider.StartUI();
+            Stack.Clear();
+        }
+
+        /// <inheritdoc/>
+        public void Navigate(NavigationRequest request)
+        {
+            var viewType = typeof(IView<>).MakeGenericType(request.ViewModelType);
+            var viewModel = CreateViewModel(request.ViewModelType);
+            var view = CreateView(viewType);
+            ViewProvider.SetView(view);
+            viewType.GetProperty("ViewModel").SetValue(view, viewModel);
+            SynchronousTask initViewModelTask =
+                new SynchronousTask(() => viewModel.InitializeAsync(request.Parameter));
+            initViewModelTask.RunTask();
+            view.Initialize();
+            Stack.AddRequest(request);
+        }
+
+        #endregion
+    }
+}

--- a/BassClefStudio.AppModel/Helpers/NavigationManager.cs
+++ b/BassClefStudio.AppModel/Helpers/NavigationManager.cs
@@ -1,4 +1,6 @@
-﻿using BassClefStudio.AppModel.Navigation;
+﻿using Autofac;
+using BassClefStudio.AppModel.Lifecycle;
+using BassClefStudio.AppModel.Navigation;
 using BassClefStudio.NET.Core;
 using System;
 using System.Collections.Generic;
@@ -7,55 +9,91 @@ using System.Text;
 namespace BassClefStudio.AppModel.Helpers
 {
     /// <summary>
-    /// A default implementation of <see cref="INavigationService"/> that uses factory methods to create the necessary DI resources.
+    /// A default implementation of <see cref="INavigationService"/>/<see cref="IBackHandler"/> that extends the <see cref="App"/>'s <see cref="ILifetimeScope"/>.
     /// </summary>
-    public class NavigationManager : INavigationService
+    public class NavigationManager : INavigationService, IBackHandler
     {
         #region Initialization
 
         /// <summary>
         /// The injected <see cref="IViewProvider"/> for setting view content.
         /// </summary>
-        public IViewProvider ViewProvider { get; set; }
+        protected IViewProvider ViewProvider { get; }
 
         /// <summary>
-        /// The injected <see cref="INavigationStack"/> history stack.
+        /// The injected <see cref="INavigationStack"/> for managing history.
         /// </summary>
-        public INavigationStack Stack { get; set; }
+        protected INavigationStack Stack { get; }
 
         /// <summary>
-        /// The injected factory method for creating <see cref="IView"/>s of the given type.
+        /// The <see cref="ILifetimeScope"/> delegated by the <see cref="App"/> to the <see cref="NavigationManager"/> to resolve view and view-model instances.
         /// </summary>
-        public Func<Type, IView> CreateView { get; set; }
+        protected ILifetimeScope LifetimeScope { get; }
 
         /// <summary>
-        /// The injected factory method for creating <see cref="IViewModel"/>s of the given type.
+        /// Creates a new <see cref="NavigationManager"/> from the provided services.
         /// </summary>
-        public Func<Type, IViewModel> CreateViewModel { get; set; }
+        public NavigationManager(IViewProvider viewProvider, INavigationStack stack, ILifetimeScope scope)
+        {
+            ViewProvider = viewProvider;
+            Stack = stack;
+            LifetimeScope = scope;
+        }
 
         #endregion
         #region Methods
 
         /// <inheritdoc/>
-        public void Initialize()
+        public bool Initialize()
         {
             ViewProvider.StartUI();
             Stack.Clear();
+            return true;
         }
 
         /// <inheritdoc/>
         public void Navigate(NavigationRequest request)
         {
-            var viewType = typeof(IView<>).MakeGenericType(request.ViewModelType);
-            var viewModel = CreateViewModel(request.ViewModelType);
-            var view = CreateView(viewType);
-            ViewProvider.SetView(view);
+            IViewModel viewModel = null;
+            IView view = null;
+            Type viewType = null;
+
+            if (request.ContainsInstance)
+            {
+                viewModel = request.ViewModelInstance;
+                viewType = typeof(IView<>).MakeGenericType(request.ViewModelInstance.GetType());
+                view = (IView)LifetimeScope.Resolve(viewType);
+            }
+            else
+            {
+                viewModel = (IViewModel)LifetimeScope.Resolve(request.ViewModelType);
+                viewType = typeof(IView<>).MakeGenericType(request.ViewModelType);
+                view = (IView)LifetimeScope.Resolve(viewType);
+            }
+
             viewType.GetProperty("ViewModel").SetValue(view, viewModel);
+            ViewProvider.SetView(view, request.Mode);
+
+            //// Initializes the view-model and view.
+            view.Initialize();
             SynchronousTask initViewModelTask =
                 new SynchronousTask(() => viewModel.InitializeAsync(request.Parameter));
             initViewModelTask.RunTask();
-            view.Initialize();
             Stack.AddRequest(request);
+        }
+
+        /// <inheritdoc/>
+        public bool GoBack()
+        {
+            if(Stack.CanGoBack)
+            {
+                this.GoBack(Stack);
+                return true;
+            }
+            else
+            {
+                return false;
+            }
         }
 
         #endregion

--- a/BassClefStudio.AppModel/Helpers/ShellViewModel.cs
+++ b/BassClefStudio.AppModel/Helpers/ShellViewModel.cs
@@ -82,7 +82,7 @@ namespace BassClefStudio.AppModel.Helpers
         /// <summary>
         /// The injected <see cref="IViewProvider"/>, which can be queried to setup the shell view settings for a given platform.
         /// </summary>
-        public IViewProvider NavigationService { get; set; }
+        public INavigationService NavigationService { get; set; }
 
         /// <summary>
         /// Creates a new <see cref="ShellViewModel"/>.
@@ -91,7 +91,6 @@ namespace BassClefStudio.AppModel.Helpers
         {
             NavigationItems = new ObservableCollection<NavigationItem>(GetInitialItems());
             MyApp = myApp;
-            MyApp.Navigated += AppNavigated;
             NavigateCommand = new StreamCommand<NavigationItem>(
                 new CommandInfo()
                 {
@@ -130,12 +129,12 @@ namespace BassClefStudio.AppModel.Helpers
         /// <inheritdoc/>
         public abstract Task InitializeAsync(object parameter = null);
 
-        private void AppNavigated(object sender, NavigatedEventArgs e)
-        {
-            var viewModelType = e.NavigatedViewModel.GetType();
-            SetSelected(NavigationItems.FirstOrDefault(i => i.ViewModelType == viewModelType && i.Parameter == e.Parameter));
-            backEnabledInternal.EmitValue(MyApp.CanGoBack);
-        }
+        //private void AppNavigated(object sender, NavigatedEventArgs e)
+        //{
+        //    var viewModelType = e.NavigatedViewModel.GetType();
+        //    SetSelected(NavigationItems.FirstOrDefault(i => i.ViewModelType == viewModelType && i.Parameter == e.Parameter));
+        //    backEnabledInternal.EmitValue(MyApp.CanGoBack);
+        //}
 
         /// <summary>
         /// Navigates the <see cref="App"/> to the specified page (sets the <see cref="SelectedItem"/> property).

--- a/BassClefStudio.AppModel/Helpers/ShellViewModel.cs
+++ b/BassClefStudio.AppModel/Helpers/ShellViewModel.cs
@@ -80,9 +80,9 @@ namespace BassClefStudio.AppModel.Helpers
         public App MyApp { get; set; }
 
         /// <summary>
-        /// The injected <see cref="INavigationService"/>, which can be queried to setup the shell view settings for a given platform.
+        /// The injected <see cref="IViewProvider"/>, which can be queried to setup the shell view settings for a given platform.
         /// </summary>
-        public INavigationService NavigationService { get; set; }
+        public IViewProvider NavigationService { get; set; }
 
         /// <summary>
         /// Creates a new <see cref="ShellViewModel"/>.

--- a/BassClefStudio.AppModel/Lifecycle/ILifecycleHandlers.cs
+++ b/BassClefStudio.AppModel/Lifecycle/ILifecycleHandlers.cs
@@ -31,6 +31,18 @@ namespace BassClefStudio.AppModel.Lifecycle
     }
 
     /// <summary>
+    /// Represents a service that can manage system requests to return to a previous state (i.e. a software or hardware back button, for example).
+    /// </summary>
+    public interface IBackHandler : ILifecycleHandler
+    {
+        /// <summary>
+        /// A method that is called whenever system back navigation is requested.
+        /// </summary>
+        /// <returns>A <see cref="bool"/> value indicating whether any action was performed successfully.</returns>
+        bool GoBack();
+    }
+
+    /// <summary>
     /// Represents a view-model that can manage an <see cref="App"/>'s foreground activation.
     /// </summary>
     public interface IActivationHandler : ILifecycleHandler, IViewModel

--- a/BassClefStudio.AppModel/Lifecycle/ILifecycleHandlers.cs
+++ b/BassClefStudio.AppModel/Lifecycle/ILifecycleHandlers.cs
@@ -14,9 +14,8 @@ namespace BassClefStudio.AppModel.Lifecycle
         /// <summary>
         /// A method that is called when the <see cref="App"/> initializes.
         /// </summary>
-        /// <param name="app">The app's <see cref="App"/> object.</param>
         /// <returns>A <see cref="bool"/> value indicating whether any action was performed successfully.</returns>
-        bool Initialize(App app);
+        bool Initialize();
     }
 
     /// <summary>
@@ -27,9 +26,8 @@ namespace BassClefStudio.AppModel.Lifecycle
         /// <summary>
         /// A method that is called whenever a foreground-activated <see cref="App"/> is closing or returning to the background. Here, the <see cref="ILifecycleHandler"/> can dispose or broker resources before the <see cref="App"/> has fully closed.
         /// </summary>
-        /// <param name="app">The app's <see cref="App"/> object.</param>
         /// <returns>A <see cref="bool"/> value indicating whether any action was performed successfully.</returns>
-        bool Suspend(App app);
+        bool Suspend();
     }
 
     /// <summary>

--- a/BassClefStudio.AppModel/Navigation/INavigationService.cs
+++ b/BassClefStudio.AppModel/Navigation/INavigationService.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using BassClefStudio.AppModel.Lifecycle;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -7,7 +8,96 @@ namespace BassClefStudio.AppModel.Navigation
     /// <summary>
     /// A service that controls an <see cref="INavigationStack"/> and platform-specific <see cref="IViewProvider"/>s to navigate between <see cref="IViewModel"/> models and serve relevant <see cref="IView"/> UI to the user.
     /// </summary>
-    public interface INavigationService
+    public interface INavigationService : IInitializationHandler
     {
+        /// <summary>
+        /// Navigates to a <see cref="IViewModel"/> using the given <see cref="NavigationRequest"/>.
+        /// </summary>
+        void Navigate(NavigationRequest request);
+    }
+
+    /// <summary>
+    /// A description of how to navigate to a specific state in the app, used by <see cref="INavigationService"/> and stored in the <see cref="INavigationStack"/>'s history.
+    /// </summary>
+    public struct NavigationRequest
+    {
+        /// <summary>
+        /// The <see cref="Type"/> of the <see cref="IViewModel"/> being navigated to.
+        /// </summary>
+        public Type ViewModelType { get; set; }
+
+        /// <summary>
+        /// An <see cref="object"/> parameter being passed to the <see cref="IViewModel.InitializeAsync(object)"/> task when navigation occurs.
+        /// </summary>
+        public object Parameter { get; set; }
+
+        /// <summary>
+        /// The <see cref="NavigationMode"/> describing the behavior of the navigation operation.
+        /// </summary>
+        public NavigationMode Mode { get; set; }
+
+        /// <summary>
+        /// Creates a new <see cref="NavigationRequest"/>.
+        /// </summary>
+        /// <param name="viewModelType">The <see cref="Type"/> of the <see cref="IViewModel"/> being navigated to.</param>
+        /// <param name="mode">The <see cref="NavigationMode"/> describing the behavior of the navigation operation.</param>
+        /// <param name="parameter">An <see cref="object"/> parameter being passed to the <see cref="IViewModel.InitializeAsync(object)"/> task when navigation occurs.</param>
+        public NavigationRequest(Type viewModelType, NavigationMode mode, object parameter = null)
+        {
+            ViewModelType = viewModelType;
+            Mode = mode;
+            Parameter = parameter;
+        }
+    }
+
+    /// <summary>
+    /// Provides information about exactly how a navigation event should occur.
+    /// </summary>
+    public struct NavigationMode
+    {
+        /// <summary>
+        /// The default <see cref="NavigationMode"/> for navigating between pages.
+        /// </summary>
+        public static NavigationMode Default { get; } = new NavigationMode(NavigationOverlay.Replace);
+
+        /// <summary>
+        /// The <see cref="NavigationOverlay"/> mode that should be used to present the navigated content.
+        /// </summary>
+        public NavigationOverlay OverlayMode { get; }
+        
+        /// <summary>
+        /// If set to 'true', this indicates that the content being navigated to is transient (e.g. a login screen, one-time notification dialog, etc.) and should generally not be included in the <see cref="INavigationStack"/>.
+        /// </summary>
+        public bool IgnoreHistory { get; }
+
+        /// <summary>
+        /// Defines a new <see cref="NavigationMode"/>.
+        /// </summary>
+        /// <param name="overlayMode">The <see cref="NavigationOverlay"/> mode that should be used to present the navigated content.</param>
+        /// <param name="ignoreHistory">If set to 'true', this indicates that the content being navigated to is transient (e.g. a login screen, one-time notification dialog, etc.) and should generally not be included in the <see cref="INavigationStack"/>.</param>
+        public NavigationMode(NavigationOverlay overlayMode, bool ignoreHistory = false)
+        {
+            OverlayMode = overlayMode;
+            IgnoreHistory = ignoreHistory;
+        }
+    }
+
+    /// <summary>
+    /// The type of overlay that should be produced when the new content is navigated to.
+    /// </summary>
+    public enum NavigationOverlay
+    {
+        /// <summary>
+        /// Fully replaces the existing content with the navigated content.
+        /// </summary>
+        Replace = 0,
+        /// <summary>
+        /// Displays the navigated content on top of the existing content (in a dialog or modal control).
+        /// </summary>
+        Modal = 1,
+        /// <summary>
+        /// Creates a new, movable window with the navigated content.
+        /// </summary>
+        Window = 2
     }
 }

--- a/BassClefStudio.AppModel/Navigation/INavigationService.cs
+++ b/BassClefStudio.AppModel/Navigation/INavigationService.cs
@@ -79,15 +79,8 @@ namespace BassClefStudio.AppModel.Navigation
         /// <param name="stack">The <see cref="INavigationStack"/> to use for navigation history.</param>
         public static void GoBack(this INavigationService navigationService, INavigationStack stack)
         {
-            if (stack.CanGoBack)
-            {
-                var request = stack.GoBack();
-                navigationService.Navigate(request);
-            }
-            else
-            {
-                throw new InvalidOperationException("Cannot currently go back in the navigation stack.");
-            }
+            var request = stack.GoBack();
+            navigationService.Navigate(request);
         }
 
         /// <summary>
@@ -97,15 +90,8 @@ namespace BassClefStudio.AppModel.Navigation
         /// <param name="stack">The <see cref="INavigationStack"/> to use for navigation history.</param>
         public static void GoForward(this INavigationService navigationService, INavigationStack stack)
         {
-            if (stack.CanGoForward)
-            {
-                var request = stack.GoBack();
-                navigationService.Navigate(request);
-            }
-            else
-            {
-                throw new InvalidOperationException("Cannot currently go forward in the navigation stack.");
-            }
+            var request = stack.GoBack();
+            navigationService.Navigate(request);
         }
     }
 }

--- a/BassClefStudio.AppModel/Navigation/INavigationService.cs
+++ b/BassClefStudio.AppModel/Navigation/INavigationService.cs
@@ -1,108 +1,13 @@
-﻿using Autofac;
-using BassClefStudio.AppModel.Lifecycle;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Text;
 
 namespace BassClefStudio.AppModel.Navigation
 {
     /// <summary>
-    /// Represents a service that can navigate between <see cref="IView{T}"/>s in a platform-specific way. This interface is generally for internal use, and for most navigation apps should use the methods available on the <see cref="App"/> class instead, as they provide additional functionality.
+    /// A service that controls an <see cref="INavigationStack"/> and platform-specific <see cref="IViewProvider"/>s to navigate between <see cref="IViewModel"/> models and serve relevant <see cref="IView"/> UI to the user.
     /// </summary>
     public interface INavigationService
     {
-        /// <summary>
-        /// Called when the app has been activated with UI, this method should enable the UI, build windows, and start this <see cref="INavigationService"/>'s navigation context.
-        /// </summary>
-        void InitializeNavigation();
-
-        /// <summary>
-        /// Navigates to the given <see cref="IView"/> view, displaying its content to the user.
-        /// </summary>
-        /// <param name="view">The instance of the <see cref="IView"/> to navigate to.</param>
-        /// <returns>A <see cref="bool"/> indicating whether the <see cref="IView"/> overlays or replaces existing content. If 'false', another window or dialog was launched to show the <see cref="IView"/> instead.</returns>
-        bool Navigate(IView view);
-
-        /// <summary>
-        /// A <see cref="bool"/> indicating whether this <see cref="INavigationService"/> supports back navigation in its current state. 
-        /// </summary>
-        bool CanGoBack { get; }
-
-        /// <summary>
-        /// Initiate back navigation and navigate to the previously visited <see cref="IView"/> view.
-        /// </summary>
-        /// <returns>The <see cref="IView"/> that has been navigated to.</returns>
-        IView GoBack();
-    }
-
-    /// <summary>
-    /// Represents a base <see cref="INavigationService"/> that navigates between views of type <typeparamref name="T"/> and implements stack-based back navigation.
-    /// </summary>
-    /// <typeparam name="T">The type of views this <see cref="NavigationService{T}"/> navigates between.</typeparam>
-    public abstract class NavigationService<T> : INavigationService
-    {
-        /// <inheritdoc/>
-        public bool CanGoBack => NavigationStack.Count > 1;
-
-        /// <summary>
-        /// The <see cref="Stack{T}"/> containing back navigation information.
-        /// </summary>
-        protected Stack<T> NavigationStack { get; }
-
-        /// <summary>
-        /// Creates a new <see cref="NavigationService{T}"/>.
-        /// </summary>
-        public NavigationService()
-        {
-            NavigationStack = new Stack<T>();
-        }
-
-        /// <inheritdoc/>
-        public abstract void InitializeNavigation();
-
-        /// <summary>
-        /// Navigates to a <typeparamref name="T"/> view internally, using the platform-specific navigation APIs.
-        /// </summary>
-        /// <param name="view">The <see cref="IView"/> and <typeparamref name="T"/> to navigate to.</param>
-        protected abstract bool NavigateInternal(T view);
-
-        /// <inheritdoc/>
-        public bool Navigate(IView view)
-        {
-            if(view is T tView)
-            {
-                bool isPage = NavigateInternal(tView);
-                if (isPage)
-                {
-                    NavigationStack.Push(tView);
-                    return true;
-                }
-                else
-                {
-                    return false;
-                }
-            }
-            else
-            {
-                throw new ArgumentException($"Navigation only supports views of type \"{typeof(T).Name}\"; view is of type \"{view?.GetType().Name}\".");
-            }
-        }
-
-        /// <inheritdoc/>
-        public IView GoBack()
-        {
-            if (CanGoBack)
-            {
-                NavigationStack.Pop();
-                var view = NavigationStack.Peek();
-                NavigateInternal(view);
-                return (view as IView);
-            }
-            else
-            {
-                throw new InvalidOperationException("Cannot initiate back navigation - CanGoBack is currently 'false'.");
-            }
-        }
     }
 }

--- a/BassClefStudio.AppModel/Navigation/INavigationStack.cs
+++ b/BassClefStudio.AppModel/Navigation/INavigationStack.cs
@@ -9,5 +9,37 @@ namespace BassClefStudio.AppModel.Navigation
     /// </summary>
     public interface INavigationStack
     {
+        /// <summary>
+        /// Handles the new <see cref="NavigationRequest"/> request that has been sent by the app, adding it to history.
+        /// </summary>
+        /// <param name="request">The <see cref="NavigationRequest"/> describing the location and behavior of the most recent navigation operation.</param>
+        void AddRequest(NavigationRequest request);
+
+        /// <summary>
+        /// Clears the entire <see cref="INavigationStack"/>'s history.
+        /// </summary>
+        void Clear();
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="INavigationStack"/> has items in the current back history.
+        /// </summary>
+        bool CanGoBack { get; }
+
+        /// <summary>
+        /// Navigates backwards in the <see cref="INavigationStack"/> history.
+        /// </summary>
+        /// <returns>A <see cref="NavigationRequest"/> describing the operation required to adjust the app's view to the requrested state.</returns>
+        NavigationRequest GoBack();
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="INavigationStack"/> has items in the current forward history.
+        /// </summary>
+        bool CanGoForward { get; }
+
+        /// <summary>
+        /// Navigates forwards in the <see cref="INavigationStack"/> history.
+        /// </summary>
+        /// <returns>A <see cref="NavigationRequest"/> describing the operation required to adjust the app's view to the requrested state.</returns>
+        NavigationRequest GoForward();
     }
 }

--- a/BassClefStudio.AppModel/Navigation/INavigationStack.cs
+++ b/BassClefStudio.AppModel/Navigation/INavigationStack.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using BassClefStudio.NET.Core.Streams;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -9,6 +10,11 @@ namespace BassClefStudio.AppModel.Navigation
     /// </summary>
     public interface INavigationStack
     {
+        /// <summary>
+        /// An <see cref="IStream{T}"/> that represents all of the <see cref="NavigationRequest"/> requests this <see cref="INavigationStack"/> handles.
+        /// </summary>
+        IStream<NavigationRequest> RequestStream { get; }
+
         /// <summary>
         /// Handles the new <see cref="NavigationRequest"/> request that has been sent by the app, adding it to history.
         /// </summary>

--- a/BassClefStudio.AppModel/Navigation/INavigationStack.cs
+++ b/BassClefStudio.AppModel/Navigation/INavigationStack.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BassClefStudio.AppModel.Navigation
+{
+    /// <summary>
+    /// Represents some model of navigated content that allows for the management of a back-stack/history for navigation that is used by the <see cref="INavigationService"/> of an app.
+    /// </summary>
+    public interface INavigationStack
+    {
+    }
+}

--- a/BassClefStudio.AppModel/Navigation/INavigationStack.cs
+++ b/BassClefStudio.AppModel/Navigation/INavigationStack.cs
@@ -35,6 +35,7 @@ namespace BassClefStudio.AppModel.Navigation
         /// Navigates backwards in the <see cref="INavigationStack"/> history.
         /// </summary>
         /// <returns>A <see cref="NavigationRequest"/> describing the operation required to adjust the app's view to the requrested state.</returns>
+        /// <exception cref="InvalidOperationException">The <see cref="INavigationStack"/> cannot currently go back (see <see cref="CanGoBack"/>).</exception>
         NavigationRequest GoBack();
 
         /// <summary>
@@ -46,6 +47,7 @@ namespace BassClefStudio.AppModel.Navigation
         /// Navigates forwards in the <see cref="INavigationStack"/> history.
         /// </summary>
         /// <returns>A <see cref="NavigationRequest"/> describing the operation required to adjust the app's view to the requrested state.</returns>
+        /// <exception cref="InvalidOperationException">The <see cref="INavigationStack"/> cannot currently go forward (see <see cref="CanGoForward"/>).</exception>
         NavigationRequest GoForward();
     }
 }

--- a/BassClefStudio.AppModel/Navigation/IViewProvider.cs
+++ b/BassClefStudio.AppModel/Navigation/IViewProvider.cs
@@ -15,7 +15,7 @@ namespace BassClefStudio.AppModel.Navigation
         /// <summary>
         /// Called when the app has been activated with UI, this method should enable the UI, build windows, and start this <see cref="IViewProvider"/>'s navigation context.
         /// </summary>
-        void InitializeNavigation();
+        void StartUI();
 
         /// <summary>
         /// Sets the content of the app to an <see cref="IView"/> view.
@@ -31,7 +31,7 @@ namespace BassClefStudio.AppModel.Navigation
     public abstract class ViewProvider<T> : IViewProvider
     {
         /// <inheritdoc/>
-        public abstract void InitializeNavigation();
+        public abstract void StartUI();
 
         /// <summary>
         /// Internally sets the content of the app to an <typeparamref name="T"/> view.

--- a/BassClefStudio.AppModel/Navigation/IViewProvider.cs
+++ b/BassClefStudio.AppModel/Navigation/IViewProvider.cs
@@ -8,7 +8,7 @@ using System.Text;
 namespace BassClefStudio.AppModel.Navigation
 {
     /// <summary>
-    /// Represents a service that can set the <see cref="IView{T}"/> content of the app in a platform-specific way. This interface is generally for internal use, and for most navigation apps should use the methods available on the <see cref="INavaigationService"/> interface instead, as they provide additional functionality.
+    /// Represents a service that can set the <see cref="IView{T}"/> content of the app in a platform-specific way. This interface is generally for internal use, and for most navigation apps should use the methods available on the <see cref="INavigationService"/> interface instead, as it provides additional functionality.
     /// </summary>
     public interface IViewProvider
     {
@@ -21,7 +21,8 @@ namespace BassClefStudio.AppModel.Navigation
         /// Sets the content of the app to an <see cref="IView"/> view.
         /// </summary>
         /// <param name="view">The instance of the <see cref="IView"/> to navigate to.</param>
-        void SetView(IView view);
+        /// <param name="mode">A <see cref="NavigationMode"/> value describing how the navigated view should be presented.</param>
+        void SetView(IView view, NavigationMode mode);
     }
 
     /// <summary>
@@ -36,15 +37,16 @@ namespace BassClefStudio.AppModel.Navigation
         /// <summary>
         /// Internally sets the content of the app to an <typeparamref name="T"/> view.
         /// </summary>
-        /// <param name="view"></param>
-        protected abstract void SetViewInternal(T view);
+        /// <param name="view">The instance of the <see cref="IView"/> to navigate to.</param>
+        /// <param name="mode">A <see cref="NavigationMode"/> value describing how the navigated view should be presented.</param>
+        protected abstract void SetViewInternal(T view , NavigationMode mode);
 
         /// <inheritdoc/>
-        public void SetView(IView view)
+        public void SetView(IView view, NavigationMode mode)
         {
             if(view is T tView)
             {
-                SetViewInternal(tView);
+                SetViewInternal(tView, mode);
             }
             else
             {

--- a/BassClefStudio.AppModel/Navigation/IViewProvider.cs
+++ b/BassClefStudio.AppModel/Navigation/IViewProvider.cs
@@ -1,0 +1,55 @@
+﻿using Autofac;
+using BassClefStudio.AppModel.Lifecycle;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace BassClefStudio.AppModel.Navigation
+{
+    /// <summary>
+    /// Represents a service that can set the <see cref="IView{T}"/> content of the app in a platform-specific way. This interface is generally for internal use, and for most navigation apps should use the methods available on the <see cref="INavaigationService"/> interface instead, as they provide additional functionality.
+    /// </summary>
+    public interface IViewProvider
+    {
+        /// <summary>
+        /// Called when the app has been activated with UI, this method should enable the UI, build windows, and start this <see cref="IViewProvider"/>'s navigation context.
+        /// </summary>
+        void InitializeNavigation();
+
+        /// <summary>
+        /// Sets the content of the app to an <see cref="IView"/> view.
+        /// </summary>
+        /// <param name="view">The instance of the <see cref="IView"/> to navigate to.</param>
+        void SetView(IView view);
+    }
+
+    /// <summary>
+    /// A default implementation of <see cref="IViewProvider"/> that manages <typeparamref name="T"/> views.
+    /// </summary>
+    /// <typeparam name="T">The type of all <see cref="IView"/>s that thi s<see cref="ViewProvider{T}"/> supports.</typeparam>
+    public abstract class ViewProvider<T> : IViewProvider
+    {
+        /// <inheritdoc/>
+        public abstract void InitializeNavigation();
+
+        /// <summary>
+        /// Internally sets the content of the app to an <typeparamref name="T"/> view.
+        /// </summary>
+        /// <param name="view"></param>
+        protected abstract void SetViewInternal(T view);
+
+        /// <inheritdoc/>
+        public void SetView(IView view)
+        {
+            if(view is T tView)
+            {
+                SetViewInternal(tView);
+            }
+            else
+            {
+                throw new ArgumentException($"This ViewProvider does not support setting views of type {view?.GetType()}.", "view");
+            }
+        }
+    }
+}

--- a/BassClefStudio.AppModel/Navigation/NavigationRequest.cs
+++ b/BassClefStudio.AppModel/Navigation/NavigationRequest.cs
@@ -1,0 +1,211 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BassClefStudio.AppModel.Navigation
+{
+    /// <summary>
+    /// A description of how to navigate to a specific state in the app, used by <see cref="INavigationService"/> and stored in the <see cref="INavigationStack"/>'s history.
+    /// </summary>
+    public struct NavigationRequest : IEquatable<NavigationRequest>
+    {
+        /// <summary>
+        /// The <see cref="Type"/> of the <see cref="IViewModel"/> being navigated to.
+        /// </summary>
+        public Type ViewModelType { get; }
+
+        /// <summary>
+        /// An instance of an <see cref="IViewModel"/> to navigate to.
+        /// </summary>
+        public IViewModel ViewModelInstance { get; }
+
+        /// <summary>
+        /// A <see cref="bool"/> that, if set to 'true', indicates that a <see cref="ViewModelInstance"/> instead of a <see cref="ViewModelType"/> has been specified for this navigation operation.
+        /// </summary>
+        public bool ContainsInstance => ViewModelInstance != null;
+
+        /// <summary>
+        /// An <see cref="object"/> parameter being passed to the <see cref="IViewModel.InitializeAsync(object)"/> task when navigation occurs.
+        /// </summary>
+        public object Parameter { get; }
+
+        /// <summary>
+        /// The <see cref="NavigationMode"/> describing the behavior of the navigation operation.
+        /// </summary>
+        public NavigationMode Mode { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="NavigationRequest"/>.
+        /// </summary>
+        /// <param name="viewModelType">The <see cref="Type"/> of the <see cref="IViewModel"/> being navigated to.</param>
+        /// <param name="mode">The <see cref="NavigationMode"/> describing the behavior of the navigation operation.</param>
+        /// <param name="parameter">An <see cref="object"/> parameter being passed to the <see cref="IViewModel.InitializeAsync(object)"/> task when navigation occurs.</param>
+        public NavigationRequest(Type viewModelType, NavigationMode mode, object parameter = null)
+        {
+            ViewModelType = viewModelType;
+            ViewModelInstance = null;
+            Mode = mode;
+            Parameter = parameter;
+        }
+
+        /// <summary>
+        /// Creates a new instance-based <see cref="NavigationRequest"/>.
+        /// </summary>
+        /// <param name="viewModel">An instance of an <see cref="IViewModel"/> to navigate to.</param>
+        /// <param name="mode">The <see cref="NavigationMode"/> describing the behavior of the navigation operation.</param>
+        /// <param name="parameter">An <see cref="object"/> parameter being passed to the <see cref="IViewModel.InitializeAsync(object)"/> task when navigation occurs.</param>
+        public NavigationRequest(IViewModel viewModel, NavigationMode mode, object parameter = null)
+        {
+            ViewModelType = null;
+            ViewModelInstance = viewModel;
+            Mode = mode;
+            Parameter = parameter;
+        }
+
+        #region Operators
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            return obj is NavigationRequest request && Equals(request);
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(NavigationRequest other)
+        {
+            return EqualityComparer<Type>.Default.Equals(ViewModelType, other.ViewModelType) &&
+                   EqualityComparer<IViewModel>.Default.Equals(ViewModelInstance, other.ViewModelInstance) &&
+                   ContainsInstance == other.ContainsInstance &&
+                   EqualityComparer<object>.Default.Equals(Parameter, other.Parameter) &&
+                   EqualityComparer<NavigationMode>.Default.Equals(Mode, other.Mode);
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            int hashCode = -15731548;
+            hashCode = hashCode * -1521134295 + EqualityComparer<Type>.Default.GetHashCode(ViewModelType);
+            hashCode = hashCode * -1521134295 + EqualityComparer<IViewModel>.Default.GetHashCode(ViewModelInstance);
+            hashCode = hashCode * -1521134295 + ContainsInstance.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<object>.Default.GetHashCode(Parameter);
+            hashCode = hashCode * -1521134295 + Mode.GetHashCode();
+            return hashCode;
+        }
+
+        /// <inheritdoc/>
+        public static bool operator ==(NavigationRequest left, NavigationRequest right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <inheritdoc/>
+        public static bool operator !=(NavigationRequest left, NavigationRequest right)
+        {
+            return !(left == right);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// Provides information about exactly how a navigation event should occur.
+    /// </summary>
+    public struct NavigationMode : IEquatable<NavigationMode>
+    {
+        #region Defaults
+
+        /// <summary>
+        /// The default <see cref="NavigationMode"/> for navigating between pages.
+        /// </summary>
+        public static NavigationMode Default { get; } = new NavigationMode(NavigationOverlay.Page);
+
+        /// <summary>
+        /// The default <see cref="NavigationMode"/> for setting up a shell page (navigation UI).
+        /// </summary>
+        public static NavigationMode Shell { get; } = new NavigationMode(NavigationOverlay.Override, true);
+
+        #endregion
+
+        /// <summary>
+        /// The <see cref="NavigationOverlay"/> mode that should be used to present the navigated content.
+        /// </summary>
+        public NavigationOverlay OverlayMode { get; }
+
+        /// <summary>
+        /// If set to 'true', this indicates that the content being navigated to is transient (e.g. a login screen, one-time notification dialog, etc.) and should generally not be included in the <see cref="INavigationStack"/>.
+        /// </summary>
+        public bool IgnoreHistory { get; }
+
+        /// <summary>
+        /// Defines a new <see cref="NavigationMode"/>.
+        /// </summary>
+        /// <param name="overlayMode">The <see cref="NavigationOverlay"/> mode that should be used to present the navigated content.</param>
+        /// <param name="ignoreHistory">If set to 'true', this indicates that the content being navigated to is transient (e.g. a login screen, one-time notification dialog, etc.) and should generally not be included in the <see cref="INavigationStack"/>.</param>
+        public NavigationMode(NavigationOverlay overlayMode, bool ignoreHistory = false)
+        {
+            OverlayMode = overlayMode;
+            IgnoreHistory = ignoreHistory;
+        }
+
+        #region Operators
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            return obj is NavigationMode mode && Equals(mode);
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(NavigationMode other)
+        {
+            return OverlayMode == other.OverlayMode &&
+                   IgnoreHistory == other.IgnoreHistory;
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            int hashCode = 360113769;
+            hashCode = hashCode * -1521134295 + OverlayMode.GetHashCode();
+            hashCode = hashCode * -1521134295 + IgnoreHistory.GetHashCode();
+            return hashCode;
+        }
+
+        /// <inheritdoc/>
+        public static bool operator ==(NavigationMode left, NavigationMode right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <inheritdoc/>
+        public static bool operator !=(NavigationMode left, NavigationMode right)
+        {
+            return !(left == right);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// The type of overlay that should be produced when the new content is navigated to.
+    /// </summary>
+    public enum NavigationOverlay
+    {
+        /// <summary>
+        /// Requests the default page container display the navigated content.
+        /// </summary>
+        Page = 0,
+        /// <summary>
+        /// Fully replaces the existing content with the navigated content.
+        /// </summary>
+        Override = 1,
+        /// <summary>
+        /// Displays the navigated content on top of the existing content (in a dialog or modal control).
+        /// </summary>
+        Modal = 2,
+        /// <summary>
+        /// Creates a new, movable window with the navigated content.
+        /// </summary>
+        Window = 3
+    }
+}


### PR DESCRIPTION
**Beta version v2.0.0-beta1 of package:**

`INavigationService`, `INavigationStack`, and `IViewProvider` (formerly known as `INavigationService`) are the three refactored and redesigned services that provide robust navigation support for the `AppModel` library.

`INavigationService` acts as a helper service to the `App` and uses the dependency injection container to resolve view and view-model dependencies and create the necessary `IViewModel`/`IView<T>` instances. It receives `NavigationRequest` requests which contain a view-model type or instance, as well as a `NavigationMode` description and an `object` parameter. By default, the AppModel library provides the `NavigationManager` class that implements these features.

These are then passed to the `IViewProvider`, which is platform-specific and adjusts the UI to display the newly-navigated view. This is mostly unchanged from v1.x, however it also is passed the `NavigationMode` which determines whether the content is displayed as a page, modal dialog, window, or app/navigation shell.

The `INavigationStack` is then provided with information about the successful navigation operation, and uses that to construct a navigation history which can be traversed using the `GoBack()` and `GoForward()` methods. Each of these creates a `NavigationRequest` which instructs an `INavigationService` how to achieve this requested app state. Different `INavigationStack`s can thus use different philosophies of how back/forward navigation should work. The `NavigationMode` that is provided in every received request can also contain a `bool` describing whether the `INavigationStack` should ignore a transient or protected navigation operation because it can't be returned to.

All navigation has thus been removed from the base `App` class, and view-models/other services should request these interfaces in order to perform their own navigation operations. `App` has actually been removed from the DI container, which has been a goal of the project for some time (see #47's addition of `IPackageInfo` as an example). This completes that transition.

Additionally, the final part of `App`'s navigation - the `GoBack()` handler for the system back button - has been delegated to the `IBackHandler` service, which `NavigationManager` implements.

Closes #92, as it is no longer relevant to this navigation system.