### PR TITLE
v2.0.0-beta3 moves IViewProvider initialization to App.ActivateForeground

### DIFF
--- a/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
+++ b/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
@@ -7,7 +7,7 @@
     <Description>A .NET Standard, platform-agnostic library for creating cross-platform view-models and applications for various .NET platforms.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
-    <Version>2.0.0-beta2</Version>
+    <Version>2.0.0-beta3</Version>
     <AssemblyName>BassClefStudio.AppModel</AssemblyName>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/BassClefStudio.AppModel/Helpers/NavigationManager.cs
+++ b/BassClefStudio.AppModel/Helpers/NavigationManager.cs
@@ -46,14 +46,6 @@ namespace BassClefStudio.AppModel.Helpers
         #region Methods
 
         /// <inheritdoc/>
-        public bool Initialize()
-        {
-            ViewProvider.StartUI();
-            Stack.Clear();
-            return true;
-        }
-
-        /// <inheritdoc/>
         public void Navigate(NavigationRequest request)
         {
             IViewModel viewModel = null;
@@ -165,6 +157,7 @@ namespace BassClefStudio.AppModel.Helpers
         public void Clear()
         {
             Requests.Clear();
+            HistoryPosition = -1;
             SetCanGo();
         }
 

--- a/BassClefStudio.AppModel/Lifecycle/App.cs
+++ b/BassClefStudio.AppModel/Lifecycle/App.cs
@@ -244,6 +244,10 @@ namespace BassClefStudio.AppModel.Lifecycle
         private void ActivateForeground(IActivatedEventArgs args)
         {
             INavigationService navigationService = Services.Resolve<INavigationService>();
+            
+            IViewProvider viewProvider = Services.Resolve<IViewProvider>();
+            viewProvider.StartUI();
+
             var shellHandler = Services.ResolveOptional<IShellHandler>();
             if (shellHandler != null)
             {

--- a/BassClefStudio.AppModel/Navigation/INavigationService.cs
+++ b/BassClefStudio.AppModel/Navigation/INavigationService.cs
@@ -8,7 +8,7 @@ namespace BassClefStudio.AppModel.Navigation
     /// <summary>
     /// An extension to the <see cref="App"/> DI container that produces and manages navigating between <see cref="IViewModel"/>s.
     /// </summary>
-    public interface INavigationService : IInitializationHandler
+    public interface INavigationService
     {
         /// <summary>
         /// Navigates to a <see cref="IViewModel"/> using the given <see cref="NavigationRequest"/>.


### PR DESCRIPTION
This prevents the view from being initialized before the app platform has actually created a UI (such as UWP, see #100).

Closes #100.