### PR TITLE
Added ICommandProvider for app-wide commands

### DIFF
--- a/BassClefStudio.AppModel.Tests/BassClefStudio.AppModel.Tests.csproj
+++ b/BassClefStudio.AppModel.Tests/BassClefStudio.AppModel.Tests.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="Autofac.Extras.Moq" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.4" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
     <PackageReference Include="coverlet.collector" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
+++ b/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
@@ -7,7 +7,7 @@
     <Description>A .NET Standard, platform-agnostic library for creating cross-platform view-models and applications for various .NET platforms.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
-    <Version>2.0.0-preview.2</Version>
+    <Version>2.0.0-preview.3</Version>
     <AssemblyName>BassClefStudio.AppModel</AssemblyName>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/BassClefStudio.AppModel/Commands/ICommandHandler.cs
+++ b/BassClefStudio.AppModel/Commands/ICommandHandler.cs
@@ -8,7 +8,7 @@ using System.Text;
 namespace BassClefStudio.AppModel.Commands
 {
     /// <summary>
-    /// A service (usually an <see cref="IViewModel"/>) that provides a set of <see cref="ICommand"/> commands that it handles.
+    /// Any service that provides a set of <see cref="ICommand"/> commands that it handles.
     /// </summary>
     public interface ICommandHandler
     {
@@ -17,6 +17,12 @@ namespace BassClefStudio.AppModel.Commands
         /// </summary>
         ICommand[] Commands { get; }
     }
+
+    /// <summary>
+    /// An <see cref="ICommandHandler"/> that's not attached to an active view-model, but instad provides app-wide command definitions.
+    /// </summary>
+    public interface ICommandProvider : ICommandHandler
+    { }
 
     /// <summary>
     /// Provides extension methods for the <see cref="ICommandHandler"/> interface.

--- a/BassClefStudio.AppModel/Helpers/BaseCommandRouter.cs
+++ b/BassClefStudio.AppModel/Helpers/BaseCommandRouter.cs
@@ -2,12 +2,13 @@
 using BassClefStudio.AppModel.Navigation;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace BassClefStudio.AppModel.Helpers
 {
     /// <summary>
-    /// Represents a default <see cref="ICommandRouter"/> that populates the available <see cref="ICommand"/>s using <see cref="INavigationHistory"/>.
+    /// Represents a default <see cref="ICommandRouter"/> that populates the available <see cref="ICommand"/>s using <see cref="INavigationHistory"/> for view-models and all resolved <see cref="ICommandProvider"/>s in the app.
     /// </summary>
     public class BaseCommandRouter : ICommandRouter
     {
@@ -17,14 +18,20 @@ namespace BassClefStudio.AppModel.Helpers
         public INavigationHistory NavigationHistory { get; }
 
         /// <summary>
+        /// The injected collection of all <see cref="ICommandProvider"/>s.
+        /// </summary>
+        public IEnumerable<ICommandProvider> CommandProviders { get; }
+
+        /// <summary>
         /// Creates a new <see cref="BaseCommandRouter"/>.
         /// </summary>
-        public BaseCommandRouter(INavigationHistory navigationHistory)
+        public BaseCommandRouter(INavigationHistory navigationHistory, IEnumerable<ICommandProvider> commandProviders)
         {
             NavigationHistory = navigationHistory;
+            CommandProviders = commandProviders;
         }
 
         /// <inheritdoc/>
-        public ICommand GetCommand(CommandInfo command) => NavigationHistory.GetActiveViewModels().GetCommand(command);
+        public ICommand GetCommand(CommandInfo command) => NavigationHistory.GetActiveViewModels().AsEnumerable<ICommandHandler>().Concat(CommandProviders).GetCommand(command);
     }
 }

--- a/BassClefStudio.AppModel/Lifecycle/App.cs
+++ b/BassClefStudio.AppModel/Lifecycle/App.cs
@@ -315,7 +315,7 @@ namespace BassClefStudio.AppModel.Lifecycle
         }
 
         /// <summary>
-        /// Registers the <see cref="IViewModel"/>s in the given <see cref="Assembly"/> instances.
+        /// Registers the <see cref="IViewModel"/>s and <see cref="ICommandProvider"/>s in the given <see cref="Assembly"/> instances.
         /// </summary>
         /// <param name="builder">The <see cref="ContainerBuilder"/> to add services to.</param>
         /// <param name="assemblies">The <see cref="Assembly"/> objects to find the <see cref="App"/>'s <see cref="IViewModel"/>s.</param>
@@ -326,6 +326,10 @@ namespace BassClefStudio.AppModel.Lifecycle
                 .PropertiesAutowired();
             builder.RegisterAssemblyTypes(assemblies)
                 .AssignableTo<IViewModel>()
+                .PropertiesAutowired()
+                .AsImplementedInterfaces();
+            builder.RegisterAssemblyTypes(assemblies)
+                .AssignableTo<ICommandProvider>()
                 .PropertiesAutowired()
                 .AsImplementedInterfaces();
         }


### PR DESCRIPTION
`ICommandProvider` allows non view-model services to expose an `ICommandHandler` that is accessible at any point in the application. This extends the existing support for `IViewModel`s exposing `ICommandHandler` properties when they are actively shown in the app navigation.