### PR TITLE
ICommand available in generic or non-generic (no inputs)

### DIFF
--- a/BassClefStudio.AppModel.Base/BassClefStudio.AppModel.Base.csproj
+++ b/BassClefStudio.AppModel.Base/BassClefStudio.AppModel.Base.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>BassClefStudio</Authors>
-    <Version>2.0.0-preview.9</Version>
+    <Version>2.0.0-preview.10</Version>
     <Description>Services and classes for the BassClefStudio.AppModel library that provide basic features for cross-platform MVVM applications running on .NET Standard.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>

--- a/BassClefStudio.AppModel.Blazor/BassClefStudio.AppModel.Blazor.csproj
+++ b/BassClefStudio.AppModel.Blazor/BassClefStudio.AppModel.Blazor.csproj
@@ -5,7 +5,7 @@
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications on .NET 5 with Blazor.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
-    <Version>2.0.0-preview.9</Version>
+    <Version>2.0.0-preview.10</Version>
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/BassClefStudio.AppModel.Console/BassClefStudio.AppModel.Console.csproj
+++ b/BassClefStudio.AppModel.Console/BassClefStudio.AppModel.Console.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>BassClefStudio.AppModel</RootNamespace>
-    <Version>2.0.0-preview.9</Version>
+    <Version>2.0.0-preview.10</Version>
     <Authors>BassClefStudio</Authors>
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications in .NET Console applications.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>

--- a/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
+++ b/BassClefStudio.AppModel.Uwp/BassClefStudio.AppModel.Uwp.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>BassClefStudio.AppModel.Uwp</id>
-    <version>2.0.0-preview.9</version>
+    <version>2.0.0-preview.10</version>
     <title>BassClefStudio.AppModel.Uwp</title>
     <authors>BassClefStudio</authors>
     <owners>BassClefStudio</owners>
@@ -13,7 +13,7 @@
     <dependencies>
       <group targetFramework="uap10.0.17763">
         <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.2.12"/>
-        <dependency id="BassClefStudio.AppModel" version="2.0.0-preview.9"/>
+        <dependency id="BassClefStudio.AppModel" version="2.0.0-preview.10"/>
         <dependency id="BassClefStudio.NET.Core" version="2.1.0"/>
         <dependency id="Microsoft.Toolkit.Uwp.Notifications" version="7.0.2"/>
         <dependency id="Microsoft.Xaml.Behaviors.Uwp.Managed" version="2.0.1"/>

--- a/BassClefStudio.AppModel.Wpf/BassClefStudio.AppModel.Wpf.csproj
+++ b/BassClefStudio.AppModel.Wpf/BassClefStudio.AppModel.Wpf.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <Authors>BassClefStudio</Authors>
-    <Version>2.0.0-preview.9</Version>
+    <Version>2.0.0-preview.10</Version>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
     <Description>An implementation of BassClefStudio.AppModel, providing services and application classes for running cross-platform MVVM applications on .NET 5 with WPF.</Description>

--- a/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
+++ b/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
@@ -7,7 +7,7 @@
     <Description>A .NET Standard, platform-agnostic library for creating cross-platform view-models and applications for various .NET platforms.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
-    <Version>2.0.0-preview.9</Version>
+    <Version>2.0.0-preview.10</Version>
     <AssemblyName>BassClefStudio.AppModel</AssemblyName>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/BassClefStudio.AppModel/Commands/ICommand.cs
+++ b/BassClefStudio.AppModel/Commands/ICommand.cs
@@ -20,6 +20,11 @@ namespace BassClefStudio.AppModel.Commands
         /// A <see cref="CommandInfo"/> object which contains documentation and identifying info for the action this <see cref="ICommand"/> provides.
         /// </summary>
         CommandInfo Info { get; }
+
+        /// <summary>
+        /// Calls the <see cref="ICommand"/> and executes its associated action.
+        /// </summary>
+        void Execute();
     }
 
     /// <summary>

--- a/BassClefStudio.AppModel/Commands/ICommandRouter.cs
+++ b/BassClefStudio.AppModel/Commands/ICommandRouter.cs
@@ -45,7 +45,10 @@ namespace BassClefStudio.AppModel.Commands
         /// </summary>
         /// <param name="command">The <see cref="CommandInfo"/> command to execute.</param>
         /// <param name="parameter">An optional input to pass to the command.</param>
-        public static void Execute<T>(CommandInfo<T> command, T parameter = default(T)) => Instance.Execute(new CommandRequest<T>() { Command = command, Parameter = parameter });
+        public static void Execute<T>(CommandInfo<T> command, T parameter = default(T)) => Instance.Execute<T>(new CommandRequest<T>() { Command = command, Parameter = parameter });
+
+        /// <inheritdoc cref="CommandRouterExtensions.Execute(ICommandRouter, CommandInfo)"/>
+        public static void Execute(CommandInfo command) => Instance.Execute(command);
 
         /// <inheritdoc cref="CommandRouterExtensions.GetEnabled(ICommandRouter, CommandInfo)"/>
         public static IStream<bool> GetEnabled(CommandInfo command) => Instance.GetEnabled(command);
@@ -71,13 +74,23 @@ namespace BassClefStudio.AppModel.Commands
     public static class CommandRouterExtensions
     {
         /// <summary>
-        /// Uses the <see cref="ICommandRouter"/> to route a given <see cref="CommandRequest{T}"/> to the corresponding <see cref="ICommand"/>.
+        /// Uses the <see cref="ICommandRouter"/> to route a given <see cref="CommandRequest{T}"/> to the corresponding <see cref="ICommand{T}"/>.
         /// </summary>
         /// <param name="router">The <see cref="ICommandRouter"/> to use to retrieve <see cref="ICommand"/> instances.</param>
         /// <param name="request">A <see cref="CommandRequest{T}"/> sent by the app that needs to be handled.</param>
         public static void Execute<T>(this ICommandRouter router, CommandRequest<T> request)
         {
             router.GetCommand(request.Command).Execute(request.Parameter);
+        }
+
+        /// <summary>
+        /// Uses the <see cref="ICommandRouter"/> to route a given <see cref="CommandInfo"/> to the corresponding <see cref="ICommand"/>.
+        /// </summary>
+        /// <param name="router">The <see cref="ICommandRouter"/> to use to retrieve <see cref="ICommand"/> instances.</param>
+        /// <param name="command">The <see cref="CommandInfo"/> description of the command sent by the app that needs to be handled.</param>
+        public static void Execute(this ICommandRouter router, CommandInfo command)
+        {
+            router.GetCommand(command).Execute();
         }
 
         /// <summary>

--- a/BassClefStudio.AppModel/Commands/StreamCommand.cs
+++ b/BassClefStudio.AppModel/Commands/StreamCommand.cs
@@ -6,6 +6,55 @@ using System.Text;
 namespace BassClefStudio.AppModel.Commands
 {
     /// <summary>
+    /// Represents a basic <see cref="ICommand"/> which uses <see cref="SourceStream{T}"/> for executing some action when the command is triggered.
+    /// </summary>
+    public class StreamCommand : ICommand, IStream<bool>
+    {
+        /// <summary>
+        /// A <see cref="SourceStream{T}"/> which can be used to trigger the action defined by this <see cref="StreamCommand{T}"/>.
+        /// </summary>
+        public SourceStream<bool> TriggerStream { get; }
+
+        /// <inheritdoc/>
+        public IStream<bool> EnabledStream { get; }
+
+        /// <inheritdoc/>
+        public bool Started { get; }
+
+        /// <inheritdoc/>
+        public CommandInfo Info { get; }
+
+        /// <inheritdoc/>
+        public StreamBinding<bool> ValueEmitted { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="StreamCommand{T}"/>.
+        /// </summary>
+        /// <param name="info">A <see cref="CommandInfo"/> object which contains documentation and identifying info for the action this <see cref="ICommand{T}"/> provides.</param>
+        /// <param name="enableStream">An <see cref="IStream{T}"/> that emits <see cref="bool"/> values indicating whether this <see cref="StreamCommand{T}"/> should be enabled or not.</param>
+        public StreamCommand(CommandInfo info, IStream<bool> enableStream = null)
+        {
+            Info = info;
+            TriggerStream = new SourceStream<bool>();
+            ValueEmitted = TriggerStream.ValueEmitted;
+            EnabledStream = enableStream ?? true.AsStream();
+        }
+
+        /// <inheritdoc/>
+        public void Start()
+        {
+            TriggerStream.Start();
+            EnabledStream.Start();
+        }
+
+        /// <inheritdoc/>
+        public void Execute()
+        {
+            TriggerStream.EmitValue(true);
+        }
+    }
+
+    /// <summary>
     /// Represents a basic <see cref="ICommand{T}"/> which uses <see cref="SourceStream{T}"/> for executing some action when the command is triggered.
     /// </summary>
     /// <typeparam name="T">The type of inputs this <see cref="ICommand{T}"/> accepts.</typeparam>
@@ -50,6 +99,8 @@ namespace BassClefStudio.AppModel.Commands
             EnabledStream.Start();
         }
 
+        /// <inheritdoc/>
+        void ICommand.Execute() => Execute();
         /// <inheritdoc/>
         public void Execute(T input = default(T))
         {

--- a/BassClefStudio.AppModel/Helpers/ShellViewModel.cs
+++ b/BassClefStudio.AppModel/Helpers/ShellViewModel.cs
@@ -33,7 +33,7 @@ namespace BassClefStudio.AppModel.Helpers
         /// <summary>
         /// A command for triggering available back navigation.
         /// </summary>
-        public static CommandInfo<bool> BackCommand { get; } = new CommandInfo<bool>()
+        public static CommandInfo BackCommand { get; } = new CommandInfo()
         {
             Id = "Shell/Back",
             FriendlyName = "Go back",
@@ -96,7 +96,7 @@ namespace BassClefStudio.AppModel.Helpers
             BackEnabled = NavigationService.History.RequestStream
                 .Select(r => NavigationService.History.CanGoBack);
             
-            var back = new StreamCommand<bool>(ShellViewModel.BackCommand, BackEnabled);
+            var back = new StreamCommand(ShellViewModel.BackCommand, BackEnabled);
             back.BindResult(b => NavigationService.GoBack());
 
             Commands = new List<ICommand>() { navigate, back };


### PR DESCRIPTION
Adjusts the changes made in #122 to allow for commands to also optionally implement the `ICommand` interface and use `StreamCommand` without inputs and strongly-typed generic parameters. Reduces verbosity and confusion in this use case.