### PR TITLE
Fixes ShellViewModel type-unsafe settings navigation 

### DIFF
--- a/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
+++ b/BassClefStudio.AppModel/BassClefStudio.AppModel.csproj
@@ -7,7 +7,7 @@
     <Description>A .NET Standard, platform-agnostic library for creating cross-platform view-models and applications for various .NET platforms.</Description>
     <PackageProjectUrl>https://github.com/bassclefstudio/AppModel</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/AppModel.git</RepositoryUrl>
-    <Version>2.0.0-preview.10</Version>
+    <Version>2.0.0-preview.11</Version>
     <AssemblyName>BassClefStudio.AppModel</AssemblyName>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/BassClefStudio.AppModel/Helpers/ShellViewModel.cs
+++ b/BassClefStudio.AppModel/Helpers/ShellViewModel.cs
@@ -91,7 +91,6 @@ namespace BassClefStudio.AppModel.Helpers
             
             var navigate = new StreamCommand<NavigationItem>(ShellViewModel.NavigateCommand);
             navigate.BindResult(Navigate);
-            navigate.Where(o => !(o is NavigationItem)).BindResult(b => Navigate(SettingsItem));
 
             BackEnabled = NavigationService.History.RequestStream
                 .Select(r => NavigationService.History.CanGoBack);


### PR DESCRIPTION
`ShellViewModel` removes the type-unsafe settings navigation command handler (navigate to settings using normal command behavior instead).

Closes #126.